### PR TITLE
Add publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -26,10 +26,10 @@ dependsOn:
       versionMin: '3.5'
       optional: false 
 maintenance:
-  type: community
+  type: internal 
   contacts:
-    - name: Enrico Zini
-      email: enrico@truelite.it
+    - name: Truelite srl 
+      email: a38@truelite.it
 legal:
   license: Apache-2.0
   mainCopyrightOwner: Enrico Zini

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,57 @@
+publiccodeYmlVersion: '0.2'
+name: A38
+url: 'https://github.com/Truelite/python-a38.git'
+softwareVersion: 0.1.1
+releaseDate: '2019-03-07'
+inputTypes:
+  - text/xml
+outputTypes:
+  - text/html
+  - text/xml
+  - application/pdf
+platforms:
+  - linux
+categories:
+  - billing-and-invoicing
+developmentStatus: beta
+softwareType: library
+dependsOn:
+  open:
+    - name: Python
+      versionMin: '3.5'
+      optional: false 
+maintenance:
+  type: community
+  contacts:
+    - name: Enrico Zini
+      email: enrico@truelite.it
+legal:
+  license: Apache-2.0
+  mainCopyrightOwner: Enrico Zini
+intendedAudience:
+  countries:
+    - it
+localisation:
+  localisationReady: false
+  availableLanguages:
+    - it
+description:
+  en:
+    shortDescription: |
+      parse and generate Italian Fattura Elettronica
+    longDescription: >
+      This library implements a declarative data model similar to Django models,
+      that is designed to describe, validate, serialize and parse Italian
+      Fattura Elettronica data.
+
+      Only part of the specification is implemented, with more added as needs
+      will arise. Anyone is welcome to implement the missing pieces they need
+      and send a pull request: the idea is to have a good, free (as in freedom)
+      library to make billing in Italy with Python easier for everyone.
+
+      The library can generate various kinds of fatture that pass validation,
+      and can parse all the example XML files distributed by fatturapa.gov.it
+    features:
+      - |
+        Implement the Italian Fattura Elettronica in a declarative data model
+    genericName: Library

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -8,9 +8,14 @@ inputTypes:
 outputTypes:
   - text/html
   - text/xml
+  - text/x-python
   - application/pdf
+  - application/json
+  - application/x-x509-ca-cert
 platforms:
   - linux
+  - windows
+  - ios
 categories:
   - billing-and-invoicing
 developmentStatus: beta
@@ -34,7 +39,7 @@ intendedAudience:
 localisation:
   localisationReady: false
   availableLanguages:
-    - it
+    - en 
 description:
   en:
     shortDescription: |


### PR DESCRIPTION
La presente PR aggiunge il file `publiccode.yml` aderente alle ultime specifiche `core-0.2;it-0.2` illustrate sul portale [Docs Italia](https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/index.html).

Al momento alcune informazioni devono essere riviste e, per questo motivo, la PR è in modalità `Work-In-Progress`.
Nello specifico, mi servirebbero ulteriori informazioni riguardanti:
- [x] `repoOwner` -> in questo caso direi che è `Truelite srl`
- [x] Lista delle PA che attualmente utilizzano l'applicativo (da aggiungere alla chiave`usedBy`).
- [x] Aggiungere degli `screenshot` dell'applicativo (da inserire nel repository, ad esempio nella folder `screenshot` nella root).

Ovviamente rimango a disposizione per apportare qualsiasi correzione e/o integrazione necessaria al file.

Grazie molte per la disponibilità! @valholl @spanezz 