### PR TITLE
Add the optional key legal/repoOwner

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -33,6 +33,7 @@ maintenance:
 legal:
   license: Apache-2.0
   mainCopyrightOwner: Enrico Zini
+  repoOwner: Truelite srl
 intendedAudience:
   countries:
     - it


### PR DESCRIPTION
Please, add the optional Publiccode key "legal/repoOwner" with a key value of your choice. The chosen key value will appear under "Published by" in your software's web page on the developers.italia.it catalogue (https://developers.italia.it/en/software/truelite-python-a38-2b079c).