### PR TITLE
Feature/lint static code analysis type checking vulnerability scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,68 @@ install-os:
 
 install-py:
 	pip install -r requirements-lib.txt
+	pip install -r requirements-devops.txt
 
 test:
 	sh test-coverage
 
 install-package:
 	pip install .
+
+clean:
+	rm \
+		--recursive --force \
+		$(PWD)/build \
+		$(PWD)/dist \
+		$(PWD)/htmlcov \
+		$(PWD)/a38.egg-info \
+		$(PWD)/.coverage
+
+lint:
+# The command `isort` sometimes applies a slightly unreadable import style, whereas `black` doesnt.
+# However `isort` sorts out much more issues with imports.
+# This way we apply `black` twice and make sure the `make lint` command is idempotent.
+	black \
+		--check \
+		$(PWD)/a38 \
+		$(PWD)/tests
+	isort \
+		--atomic \
+		$(PWD)/a38 \
+		$(PWD)/tests
+	black \
+		$(PWD)/a38 \
+		$(PWD)/tests
+# E203 usually happens in `:` ranges inside the `[...]` operator. In this scenario
+# the rules applied by `black` are preferred.
+# E501 is about lines longer than 79 characters, but we want `black` to drive this rule
+# based on the context around that line in the source code.
+# TODO introduce "cyclomatic complexity" with `flake8` (C901) via `--max-complexity=4`
+	flake8 \
+		--ignore=E203,E501,W503 \
+		--jobs=8 \
+		$(PWD)/a38 \
+		$(PWD)/tests
+# The `pylint` is very aggressive and widespread - it might be worth removing some codes from the disabled rules
+# and see what is going on with those areas of the code.
+# In some cases we want to disable some checks e.g. C0301 in favor of other tools e.g. `black`.
+# TODO enable E1101,E1133,R0912 and many more and make sense of it.
+# TODO sort out types and circular dependencies due to `a38/fields.py`
+# pylint \
+# 	--disable=C0103,C0114,C0115,C0116,C0301,E1101,E1133,R0201,R0903,R0912,R0914,W0231,W0511,W1510 \
+# 	--jobs=4 \
+# 	--extension-pkg-allow-list=lxml \
+# 	$(PWD)/a38 \
+# 	$(PWD)/tests
+# TODO sort out types in `a38/fields.py`
+# PYTHONPATH=. pytype \
+# 	--keep-going \
+# 	--jobs=8 \
+# 	$(PWD)/a38
+	bandit \
+		--recursive \
+		--number=3 \
+		-lll \
+		-iii \
+		$(PWD)/a38 \
+		$(PWD)/tests

--- a/a38/builder.py
+++ b/a38/builder.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 try:
     import lxml.etree
+
     HAVE_LXML = True
 except ModuleNotFoundError:
     HAVE_LXML = False
@@ -46,6 +47,7 @@ class Builder:
 
 
 if HAVE_LXML:
+
     class LXMLBuilder:
         def __init__(self, etreebuilder=None):
             if etreebuilder is None:

--- a/a38/builder.py
+++ b/a38/builder.py
@@ -1,5 +1,6 @@
-from contextlib import contextmanager
 import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+
 try:
     import lxml.etree
     HAVE_LXML = True

--- a/a38/crypto.py
+++ b/a38/crypto.py
@@ -27,6 +27,7 @@ class P7M:
     """
     Parse a Fattura Elettronica encoded as a .p7m file
     """
+
     def __init__(self, data: Union[str, bytes, BinaryIO]):
         """
         If data is a string, it is taken as a file name.
@@ -62,7 +63,9 @@ class P7M:
             if c.name != "certificate":
                 # The signatures I've seen so far use 'certificate' only
                 continue
-            expiration_date = c.chosen["tbs_certificate"]["validity"]["not_after"].chosen.native.replace(tzinfo=None)
+            expiration_date = c.chosen["tbs_certificate"]["validity"][
+                "not_after"
+            ].chosen.native.replace(tzinfo=None)
             if expiration_date <= now:
                 return True
         return False
@@ -76,7 +79,9 @@ class P7M:
 
         signed_data = self.content_info["content"]
         if signed_data["version"].native != "v1":
-            raise RuntimeError(f"ContentInfo/SignedData.version is {signed_data['version'].native} instead of v1")
+            raise RuntimeError(
+                f"ContentInfo/SignedData.version is {signed_data['version'].native} instead of v1"
+            )
 
         return signed_data
 
@@ -100,11 +105,21 @@ class P7M:
         """
         Verify the signature on the file
         """
-        res = subprocess.run([
-            "openssl", "cms", "-verify", "-inform", "DER", "-CApath", certdir, "-noout"],
+        res = subprocess.run(
+            [
+                "openssl",
+                "cms",
+                "-verify",
+                "-inform",
+                "DER",
+                "-CApath",
+                certdir,
+                "-noout",
+            ],
             input=self.data,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+        )
 
         # From openssl cms manpage:
         # 0   The operation was completely successfully.

--- a/a38/crypto.py
+++ b/a38/crypto.py
@@ -1,11 +1,13 @@
-from typing import Union, BinaryIO
-from asn1crypto.cms import ContentInfo
-import io
 import base64
 import binascii
-import subprocess
 import datetime
+import io
+import subprocess
 import xml.etree.ElementTree as ET
+from typing import BinaryIO, Union
+
+from asn1crypto.cms import ContentInfo
+
 from . import fattura as a38
 
 

--- a/a38/diff.py
+++ b/a38/diff.py
@@ -1,6 +1,7 @@
-from typing import Optional, Any, List
-from .traversal import Annotation, Traversal
+from typing import Any, List, Optional
+
 from . import fields
+from .traversal import Annotation, Traversal
 
 
 class Difference(Annotation):

--- a/a38/diff.py
+++ b/a38/diff.py
@@ -5,16 +5,19 @@ from .traversal import Annotation, Traversal
 
 
 class Difference(Annotation):
-    def __init__(self, prefix: Optional[str], field: "fields.Field", first: Any, second: Any):
+    def __init__(
+        self, prefix: Optional[str], field: "fields.Field", first: Any, second: Any
+    ):
         super().__init__(prefix, field)
         self.first = first
         self.second = second
 
     def __str__(self):
         return "{}: first: {}, second: {}".format(
-                self.qualified_field,
-                self.field.to_str(self.first),
-                self.field.to_str(self.second))
+            self.qualified_field,
+            self.field.to_str(self.first),
+            self.field.to_str(self.second),
+        )
 
 
 class MissingOne(Difference):
@@ -37,11 +40,17 @@ class ExtraItems(Difference):
         if diff == 1:
             return "{}: {} has 1 extra element".format(self.qualified_field, longer)
         else:
-            return "{}: {} has {} extra elements".format(self.qualified_field, longer, diff)
+            return "{}: {} has {} extra elements".format(
+                self.qualified_field, longer, diff
+            )
 
 
 class Diff(Traversal):
-    def __init__(self, prefix: Optional[str] = None, differences: Optional[List[Difference]] = None):
+    def __init__(
+        self,
+        prefix: Optional[str] = None,
+        differences: Optional[List[Difference]] = None,
+    ):
         super().__init__(prefix)
         self.differences: List[Difference]
         if differences is None:

--- a/a38/fattura.py
+++ b/a38/fattura.py
@@ -47,16 +47,23 @@ class FullNameMixin:
         if self.denominazione is None:
             if self.nome is None and self.cognome is None:
                 validation.add_error(
-                        (self._meta["nome"], self._meta["cognome"], self._meta["denominazione"]),
-                        "nome and cognome, or denominazione, must be set")
+                    (
+                        self._meta["nome"],
+                        self._meta["cognome"],
+                        self._meta["denominazione"],
+                    ),
+                    "nome and cognome, or denominazione, must be set",
+                )
             elif self.nome is None:
                 validation.add_error(
-                        self._meta["nome"],
-                        "nome and cognome must both be set if denominazione is empty")
+                    self._meta["nome"],
+                    "nome and cognome must both be set if denominazione is empty",
+                )
             elif self.cognome is None:
                 validation.add_error(
-                        self._meta["cognome"],
-                        "nome and cognome must both be set if denominazione is empty")
+                    self._meta["cognome"],
+                    "nome and cognome must both be set if denominazione is empty",
+                )
         else:
             should_not_be_set = []
             if self.nome is not None:
@@ -65,9 +72,11 @@ class FullNameMixin:
                 should_not_be_set.append(self._meta["cognome"])
             if should_not_be_set:
                 validation.add_error(
-                        should_not_be_set,
-                        "{} must not be set if denominazione is not empty".format(
-                            " and ".join(x.name for x in should_not_be_set)))
+                    should_not_be_set,
+                    "{} must not be set if denominazione is not empty".format(
+                        " and ".join(x.name for x in should_not_be_set)
+                    ),
+                )
 
 
 class IdFiscale(models.Model):
@@ -92,16 +101,21 @@ class DatiTrasmissione(models.Model):
     id_trasmittente = IdTrasmittente
     progressivo_invio = fields.ProgressivoInvioField()
     formato_trasmissione = fields.StringField(length=5, choices=("FPR12", "FPA12"))
-    codice_destinatario = fields.StringField(null=True, min_length=6, max_length=7, default="0000000")
+    codice_destinatario = fields.StringField(
+        null=True, min_length=6, max_length=7, default="0000000"
+    )
     contatti_trasmittente = fields.ModelField(ContattiTrasmittente, null=True)
-    pec_destinatario = fields.StringField(null=True, min_length=8, max_length=256, xmltag="PECDestinatario")
+    pec_destinatario = fields.StringField(
+        null=True, min_length=8, max_length=256, xmltag="PECDestinatario"
+    )
 
     def validate_model(self, validation):
         super().validate_model(validation)
         if self.codice_destinatario is None and self.pec_destinatario is None:
             validation.add_error(
-                    (self._meta["codice_destinatario"], self._meta["pec_destinatario"]),
-                    "one of codice_destinatario or pec_destinatario must be set")
+                (self._meta["codice_destinatario"], self._meta["pec_destinatario"]),
+                "one of codice_destinatario or pec_destinatario must be set",
+            )
 
         # Se la fattura deve essere recapitata ad un soggetto che intende
         # ricevere le fatture elettroniche attraverso il canale PEC, il campo
@@ -110,28 +124,35 @@ class DatiTrasmissione(models.Model):
 
         if self.pec_destinatario is None and self.codice_destinatario == "0000000":
             validation.add_error(
-                    (self._meta["codice_destinatario"], self._meta["pec_destinatario"]),
-                    "pec_destinatario has no value while codice_destinatario has value 0000000",
-                    code="00426")
+                (self._meta["codice_destinatario"], self._meta["pec_destinatario"]),
+                "pec_destinatario has no value while codice_destinatario has value 0000000",
+                code="00426",
+            )
 
-        if (self.pec_destinatario is not None and self.codice_destinatario is
-                not None and self.codice_destinatario != "0000000"):
+        if (
+            self.pec_destinatario is not None
+            and self.codice_destinatario is not None
+            and self.codice_destinatario != "0000000"
+        ):
             validation.add_error(
-                    (self._meta["codice_destinatario"], self._meta["pec_destinatario"]),
-                    "pec_destinatario has value while codice_destinatario has value 0000000",
-                    code="00426")
+                (self._meta["codice_destinatario"], self._meta["pec_destinatario"]),
+                "pec_destinatario has value while codice_destinatario has value 0000000",
+                code="00426",
+            )
 
         if self.formato_trasmissione == "FPA12" and len(self.codice_destinatario) == 7:
             validation.add_error(
-                    self._meta["codice_destinatario"],
-                    "codice_destinatario has 7 characters on a Fattura PA",
-                    code="00427")
+                self._meta["codice_destinatario"],
+                "codice_destinatario has 7 characters on a Fattura PA",
+                code="00427",
+            )
 
         if self.formato_trasmissione == "FPR12" and len(self.codice_destinatario) == 6:
             validation.add_error(
-                    self._meta["codice_destinatario"],
-                    "codice_destinatario has 6 characters on a Fattura Privati",
-                    code="00427")
+                self._meta["codice_destinatario"],
+                "codice_destinatario has 6 characters on a Fattura Privati",
+                code="00427",
+            )
 
 
 class Anagrafica(FullNameMixin, models.Model):
@@ -139,7 +160,9 @@ class Anagrafica(FullNameMixin, models.Model):
     nome = fields.StringField(max_length=60, null=True)
     cognome = fields.StringField(max_length=60, null=True)
     titolo = fields.StringField(min_length=2, max_length=10, null=True)
-    cod_eori = fields.StringField(xmltag="CodEORI", min_length=13, max_length=17, null=True)
+    cod_eori = fields.StringField(
+        xmltag="CodEORI", min_length=13, max_length=17, null=True
+    )
 
 
 class DatiAnagraficiCedentePrestatore(models.Model):
@@ -152,9 +175,28 @@ class DatiAnagraficiCedentePrestatore(models.Model):
     numero_iscrizione_albo = fields.StringField(max_length=60, null=True)
     data_iscrizione_albo = fields.DateField(null=True)
     regime_fiscale = fields.StringField(
-            length=4, choices=("RF01", "RF02", "RF04", "RF05", "RF06", "RF07",
-                               "RF08", "RF09", "RF10", "RF11", "RF12", "RF13",
-                               "RF14", "RF15", "RF16", "RF17", "RF18", "RF19"))
+        length=4,
+        choices=(
+            "RF01",
+            "RF02",
+            "RF04",
+            "RF05",
+            "RF06",
+            "RF07",
+            "RF08",
+            "RF09",
+            "RF10",
+            "RF11",
+            "RF12",
+            "RF13",
+            "RF14",
+            "RF15",
+            "RF16",
+            "RF17",
+            "RF18",
+            "RF19",
+        ),
+    )
 
 
 class IndirizzoType(models.Model):
@@ -207,9 +249,10 @@ class DatiAnagraficiCessionarioCommittente(models.Model):
         super().validate_model(validation)
         if self.id_fiscale_iva is None and self.codice_fiscale is None:
             validation.add_error(
-                    (self._meta["id_fiscale_iva"], self._meta["codice_fiscale"]),
-                    "at least one of id_fiscale_iva and codice_fiscale needs to have a value",
-                    code="00417")
+                (self._meta["id_fiscale_iva"], self._meta["codice_fiscale"]),
+                "at least one of id_fiscale_iva and codice_fiscale needs to have a value",
+                code="00417",
+            )
 
 
 class RappresentanteFiscale(FullNameMixin, models.Model):
@@ -252,9 +295,13 @@ class TerzoIntermediarioOSoggettoEmittente(models.Model):
 class FatturaElettronicaHeader(models.Model):
     dati_trasmissione = DatiTrasmissione
     cedente_prestatore = CedentePrestatore
-    rappresentante_fiscale = models.ModelField(RappresentanteFiscaleCedentePrestatore, null=True)
+    rappresentante_fiscale = models.ModelField(
+        RappresentanteFiscaleCedentePrestatore, null=True
+    )
     cessionario_committente = CessionarioCommittente
-    terzo_intermediario_o_soggetto_emittente = models.ModelField(TerzoIntermediarioOSoggettoEmittente, null=True)
+    terzo_intermediario_o_soggetto_emittente = models.ModelField(
+        TerzoIntermediarioOSoggettoEmittente, null=True
+    )
     soggetto_emittente = fields.StringField(length=2, choices=("CC", "TZ"), null=True)
 
 
@@ -271,23 +318,33 @@ class DatiBollo(models.Model):
 
 
 class DatiCassaPrevidenziale(models.Model):
-    tipo_cassa = fields.StringField(length=4, choices=["TC{:02d}".format(i) for i in range(1, 23)])
+    tipo_cassa = fields.StringField(
+        length=4, choices=["TC{:02d}".format(i) for i in range(1, 23)]
+    )
     al_cassa = fields.DecimalField(max_length=6)
     importo_contributo_cassa = fields.DecimalField(max_length=15)
     imponibile_cassa = fields.DecimalField(max_length=15)
     aliquota_iva = fields.DecimalField(max_length=6, xmltag="AliquotaIVA")
     ritenuta = fields.StringField(length=2, choices=("SI",), null=True)
-    natura = fields.StringField(length=2, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"), null=True)
+    natura = fields.StringField(
+        length=2, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"), null=True
+    )
     riferimento_amministrazione = fields.StringField(max_length=20, null=True)
 
     def validate_model(self, validation):
         super().validate_model(validation)
         if self.aliquota_iva == 0 and self.natura is None:
             validation.add_error(
-                self._meta["natura"], "field is empty while aliquota_iva is zero", code="00413")
+                self._meta["natura"],
+                "field is empty while aliquota_iva is zero",
+                code="00413",
+            )
         if self.aliquota_iva != 0 and self.natura is not None:
             validation.add_error(
-                self._meta["natura"], "field has value while aliquota_iva is not zero", code="00414")
+                self._meta["natura"],
+                "field has value while aliquota_iva is not zero",
+                code="00414",
+            )
 
 
 class ScontoMaggiorazione(models.Model):
@@ -297,7 +354,9 @@ class ScontoMaggiorazione(models.Model):
 
 
 class DatiGeneraliDocumento(models.Model):
-    tipo_documento = fields.StringField(length=4, choices=("TD01", "TD02", "TD03", "TD04", "TD05", "TD06"))
+    tipo_documento = fields.StringField(
+        length=4, choices=("TD01", "TD02", "TD03", "TD04", "TD05", "TD06")
+    )
     divisa = fields.StringField()
     data = fields.DateField()
     numero = fields.StringField(max_length=20)
@@ -321,11 +380,17 @@ class DatiGeneraliDocumento(models.Model):
 
         if has_dati_cassa_previdenziale_ritenuta and not self.dati_ritenuta.has_value():
             validation.add_error(
-                self._meta["ritenuta"], "field empty when dati_cassa_previdenziale.ritenuta is SI", code="00415")
+                self._meta["ritenuta"],
+                "field empty when dati_cassa_previdenziale.ritenuta is SI",
+                code="00415",
+            )
 
         if self.numero is None or not re.search(r"\d", self.numero):
             validation.add_error(
-                self._meta["numero"], "numero must contain at least one number", code="00425")
+                self._meta["numero"],
+                "numero must contain at least one number",
+                code="00425",
+            )
 
 
 class AltriDatiGestionali(models.Model):
@@ -342,7 +407,9 @@ class CodiceArticolo(models.Model):
 
 class DettaglioLinee(models.Model):
     numero_linea = fields.IntegerField(max_length=4)
-    tipo_cessione_prestazione = fields.StringField(length=2, choices=("SC", "PR", "AB", "AC"), null=True)
+    tipo_cessione_prestazione = fields.StringField(
+        length=2, choices=("SC", "PR", "AB", "AC"), null=True
+    )
     codice_articolo = fields.ModelListField(CodiceArticolo, null=True)
     descrizione = fields.StringField(max_length=1000)
     quantita = fields.DecimalField(max_length=21, decimals=2, null=True)
@@ -354,27 +421,41 @@ class DettaglioLinee(models.Model):
     prezzo_totale = fields.DecimalField(max_length=21)
     aliquota_iva = fields.DecimalField(xmltag="AliquotaIVA", max_length=6)
     ritenuta = fields.StringField(length=2, choices=("SI",), null=True)
-    natura = fields.StringField(length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"))
+    natura = fields.StringField(
+        length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7")
+    )
     riferimento_amministrazione = fields.StringField(max_length=20, null=True)
     altri_dati_gestionali = fields.ModelListField(AltriDatiGestionali, null=True)
 
     def validate_model(self, validation):
         super().validate_model(validation)
         if self.quantita is None and self.unita_misura is not None:
-            validation.add_error(self._meta["quantita"], "field must be present when unita_misura is set")
+            validation.add_error(
+                self._meta["quantita"], "field must be present when unita_misura is set"
+            )
         if self.quantita is not None and self.unita_misura is None:
-            validation.add_error(self._meta["unita_misura"], "field must be present when quantita is set")
+            validation.add_error(
+                self._meta["unita_misura"], "field must be present when quantita is set"
+            )
         if self.aliquota_iva == 0 and self.natura is None:
             validation.add_error(
-                self._meta["natura"], "natura non presente a fronte di aliquota_iva pari a zero", code="00400")
+                self._meta["natura"],
+                "natura non presente a fronte di aliquota_iva pari a zero",
+                code="00400",
+            )
         if self.aliquota_iva != 0 and self.natura is not None:
             validation.add_error(
-                self._meta["natura"], "natura presente a fronte di aliquota_iva diversa da zero", code="00401")
+                self._meta["natura"],
+                "natura presente a fronte di aliquota_iva diversa da zero",
+                code="00401",
+            )
 
 
 class DatiRiepilogo(models.Model):
     aliquota_iva = fields.DecimalField(xmltag="AliquotaIVA", max_length=6)
-    natura = fields.StringField(length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"))
+    natura = fields.StringField(
+        length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7")
+    )
     spese_accessorie = fields.DecimalField(max_length=15, null=True)
     arrotondamento = fields.DecimalField(max_length=21, null=True)
     # FIXME: Su questo valore il sistema effettua un controllo per verificare
@@ -383,17 +464,25 @@ class DatiRiepilogo(models.Model):
     # www.fatturapa.gov.it.
     imponibile_importo = fields.DecimalField(max_length=15)
     imposta = fields.DecimalField(max_length=15)
-    esigibilita_iva = fields.StringField(xmltag="EsigibilitaIVA", length=1, choices=("I", "D", "S"), null=True)
+    esigibilita_iva = fields.StringField(
+        xmltag="EsigibilitaIVA", length=1, choices=("I", "D", "S"), null=True
+    )
     riferimento_normativo = fields.StringField(max_length=100, null=True)
 
     def validate_model(self, validation):
         super().validate_model(validation)
         if self.aliquota_iva == 0 and self.natura is None:
             validation.add_error(
-                self._meta["natura"], "field is empty while aliquota_iva is zero", code="00429")
+                self._meta["natura"],
+                "field is empty while aliquota_iva is zero",
+                code="00429",
+            )
         if self.aliquota_iva != 0 and self.natura is not None:
             validation.add_error(
-                self._meta["natura"], "field has value while aliquota_iva is not zero", code="00430")
+                self._meta["natura"],
+                "field has value while aliquota_iva is not zero",
+                code="00430",
+            )
 
 
 class DatiBeniServizi(models.Model):
@@ -446,13 +535,19 @@ class DatiBeniServizi(models.Model):
             imponibile = sum(l.prezzo_totale for l in linee)
             imposta = imponibile * aliquota / 100
             self.dati_riepilogo.append(
-                    DatiRiepilogo(
-                        aliquota_iva=aliquota, imponibile_importo=imponibile,
-                        imposta=imposta, esigibilita_iva="I"))
+                DatiRiepilogo(
+                    aliquota_iva=aliquota,
+                    imponibile_importo=imponibile,
+                    imposta=imposta,
+                    esigibilita_iva="I",
+                )
+            )
 
 
 class DatiDocumentiCorrelati(models.Model):
-    riferimento_numero_linea = fields.ListField(fields.IntegerField(max_length=4), null=True)
+    riferimento_numero_linea = fields.ListField(
+        fields.IntegerField(max_length=4), null=True
+    )
     id_documento = fields.StringField(max_length=20)
     data = fields.DateField(null=True)
     num_item = fields.StringField(max_length=20, null=True)
@@ -512,7 +607,9 @@ class DatiDDT(models.Model):
     __xmltag__ = "DatiDDT"
     numero_ddt = fields.StringField(max_length=20, xmltag="NumeroDDT")
     data_ddt = fields.DateField(xmltag="DataDDT")
-    riferimento_numero_linea = fields.ListField(fields.IntegerField(max_length=4), null=True)
+    riferimento_numero_linea = fields.ListField(
+        fields.IntegerField(max_length=4), null=True
+    )
 
 
 class FatturaPrincipale(models.Model):
@@ -537,15 +634,20 @@ class DatiGenerali(models.Model):
         dfc_dates = [x.data for x in self.dati_fatture_collegate if x.data is not None]
         if dfc_dates and self.dati_generali_documento.data < min(dfc_dates):
             validation.add_error(
-                (self.dati_fatture_collegate._meta["data"],
-                 self.dati_generali_documento._meta["data"]),
+                (
+                    self.dati_fatture_collegate._meta["data"],
+                    self.dati_generali_documento._meta["data"],
+                ),
                 "dati_generali_documento.data is earlier than dati_fatture_collegate.data",
-                code="00418")
+                code="00418",
+            )
 
 
 class DettaglioPagamento(models.Model):
     beneficiario = fields.StringField(max_length=200, null=True)
-    modalita_pagamento = fields.StringField(length=4, choices=["MP{:02d}".format(i) for i in range(1, 23)])
+    modalita_pagamento = fields.StringField(
+        length=4, choices=["MP{:02d}".format(i) for i in range(1, 23)]
+    )
     data_riferimento_termini_pagamento = fields.DateField(null=True)
     giorni_termini_pagamento = fields.IntegerField(max_length=3, null=True)
     data_scadenza_pagamento = fields.DateField(null=True)
@@ -553,7 +655,9 @@ class DettaglioPagamento(models.Model):
     cod_ufficio_postale = fields.StringField(max_length=20, null=True)
     cognome_quietanzante = fields.StringField(max_length=60, null=True)
     nome_quietanzante = fields.StringField(max_length=60, null=True)
-    cf_quietanzante = fields.StringField(max_length=16, null=True, xmltag="CFQuietanzante")
+    cf_quietanzante = fields.StringField(
+        max_length=16, null=True, xmltag="CFQuietanzante"
+    )
     titolo_quietanzante = fields.StringField(min_length=2, max_length=10, null=True)
     istituto_finanziario = fields.StringField(max_length=80, null=True)
     iban = fields.StringField(min_length=15, max_length=34, null=True, xmltag="IBAN")
@@ -568,7 +672,9 @@ class DettaglioPagamento(models.Model):
 
 
 class DatiPagamento(models.Model):
-    condizioni_pagamento = fields.StringField(length=4, choices=("TP01", "TP02", "TP03"))
+    condizioni_pagamento = fields.StringField(
+        length=4, choices=("TP01", "TP02", "TP03")
+    )
     dettaglio_pagamento = fields.ModelListField(DettaglioPagamento)
 
 
@@ -605,7 +711,10 @@ class FatturaElettronicaBody(models.Model):
         importo_totale_documento yourself, or better, extend this function and
         submit a pull request.
         """
-        totale = sum(r.imponibile_importo + r.imposta for r in self.dati_beni_servizi.dati_riepilogo)
+        totale = sum(
+            r.imponibile_importo + r.imposta
+            for r in self.dati_beni_servizi.dati_riepilogo
+        )
         self.dati_generali.dati_generali_documento.importo_totale_documento = totale
 
     def validate_model(self, validation):
@@ -619,7 +728,10 @@ class FatturaElettronicaBody(models.Model):
             if dl.aliquota_iva is not None:
                 has_aliquote_iva = True
 
-        if has_ritenute and not self.dati_generali.dati_generali_documento.dati_ritenuta.has_value():
+        if (
+            has_ritenute
+            and not self.dati_generali.dati_generali_documento.dati_ritenuta.has_value()
+        ):
             validation.add_error(
                 self.dati_generali.dati_generali_documento._meta["dati_ritenuta"],
                 "field empty while at least one of dati_beni_servizi.dettaglio_linee.ritenuta is SI",
@@ -632,10 +744,11 @@ class FatturaElettronicaBody(models.Model):
 
         if not self.dati_beni_servizi.dati_riepilogo and has_aliquote_iva:
             validation.add_error(
-                    self.dati_beni_servizi._meta["dati_riepilogo"],
-                    "dati_riepilogo is empty while there is at least an aliquota_iva"
-                    " in dettaglio_linee or dati_cassa_previdenziale",
-                    code="00419")
+                self.dati_beni_servizi._meta["dati_riepilogo"],
+                "dati_riepilogo is empty while there is at least an aliquota_iva"
+                " in dettaglio_linee or dati_cassa_previdenziale",
+                code="00419",
+            )
 
 
 class Fattura(models.Model):
@@ -648,7 +761,9 @@ class Fattura(models.Model):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = self.get_versione()
+        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = (
+            self.get_versione()
+        )
 
     def get_versione(self):
         return None
@@ -658,11 +773,17 @@ class Fattura(models.Model):
 
     def validate_model(self, validation):
         super().validate_model(validation)
-        if self.get_versione() != self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione:
+        if (
+            self.get_versione()
+            != self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione
+        ):
             validation.add_error(
-                    self.fattura_elettronica_header.dati_trasmissione._meta["formato_trasmissione"],
-                    "formato_trasmissione should be {}".format(self.get_versione()),
-                    code="00428")
+                self.fattura_elettronica_header.dati_trasmissione._meta[
+                    "formato_trasmissione"
+                ],
+                "formato_trasmissione should be {}".format(self.get_versione()),
+                code="00428",
+            )
 
     def to_xml(self, builder):
         with builder.element(self.get_xmltag(), **self.get_xmlattrs()) as b:
@@ -674,12 +795,16 @@ class Fattura(models.Model):
         """
         Build and return an ElementTree with the fattura in XML format
         """
-        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = self.get_versione()
+        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = (
+            self.get_versione()
+        )
         if lxml:
             from a38.builder import LXMLBuilder
+
             builder = LXMLBuilder()
         else:
             from a38.builder import Builder
+
             builder = Builder()
         builder.default_namespace = NS
         self.to_xml(builder)
@@ -688,10 +813,16 @@ class Fattura(models.Model):
     def from_etree(self, el):
         versione = el.attrib.get("versione", None)
         if versione is None:
-            raise RuntimeError("root element {} misses attribute 'versione'".format(el.tag))
+            raise RuntimeError(
+                "root element {} misses attribute 'versione'".format(el.tag)
+            )
 
         if versione != self.get_versione():
-            raise RuntimeError("root element versione is {} instead of {}".format(versione, self.get_versione()))
+            raise RuntimeError(
+                "root element versione is {} instead of {}".format(
+                    versione, self.get_versione()
+                )
+            )
 
         return super().from_etree(el)
 
@@ -700,6 +831,7 @@ class FatturaPrivati12(Fattura):
     """
     Fattura privati 1.2
     """
+
     def get_versione(self):
         return "FPR12"
 
@@ -708,12 +840,14 @@ class FatturaPA12(Fattura):
     """
     Fattura PA 1.2
     """
+
     def get_versione(self):
         return "FPA12"
 
 
 def auto_from_etree(root):
     from .fattura_semplificata import NS10, FatturaElettronicaSemplificata
+
     tagname_ordinaria = "{{{}}}FatturaElettronica".format(NS)
     tagname_semplificata = "{{{}}}FatturaElettronicaSemplificata".format(NS10)
 
@@ -721,7 +855,9 @@ def auto_from_etree(root):
 
     if root.tag == tagname_ordinaria:
         if versione is None:
-            raise RuntimeError("root element {} misses attribute 'versione'".format(root.tag))
+            raise RuntimeError(
+                "root element {} misses attribute 'versione'".format(root.tag)
+            )
         if versione == "FPR12":
             res = FatturaPrivati12()
         elif versione == "FPA12":
@@ -730,14 +866,19 @@ def auto_from_etree(root):
             raise RuntimeError("unsupported versione {}".format(versione))
     elif root.tag == tagname_semplificata:
         if versione is None:
-            raise RuntimeError("root element {} misses attribute 'versione'".format(root.tag))
+            raise RuntimeError(
+                "root element {} misses attribute 'versione'".format(root.tag)
+            )
         if versione == "FSM10":
             res = FatturaElettronicaSemplificata()
         else:
             raise RuntimeError("unsupported versione {}".format(versione))
     else:
-        raise RuntimeError("Root element {} is neither {} nor {}".format(
-            root.tag, tagname_ordinaria, tagname_semplificata))
+        raise RuntimeError(
+            "Root element {} is neither {} nor {}".format(
+                root.tag, tagname_ordinaria, tagname_semplificata
+            )
+        )
 
     res.from_etree(root)
     return res

--- a/a38/fattura.py
+++ b/a38/fattura.py
@@ -1,6 +1,6 @@
-from . import models
-from . import fields
 import re
+
+from . import fields, models
 
 #
 # This file describes the data model of the Italian Fattura Elettronica.

--- a/a38/fattura.py
+++ b/a38/fattura.py
@@ -532,7 +532,7 @@ class DatiBeniServizi(models.Model):
 
         self.dati_riepilogo = []
         for aliquota, linee in sorted(by_aliquota.items()):
-            imponibile = sum(l.prezzo_totale for l in linee)
+            imponibile = sum(linea.prezzo_totale for linea in linee)
             imposta = imponibile * aliquota / 100
             self.dati_riepilogo.append(
                 DatiRiepilogo(

--- a/a38/fattura_semplificata.py
+++ b/a38/fattura_semplificata.py
@@ -1,6 +1,13 @@
 from . import fields, models
-from .fattura import (Allegati, FullNameMixin, IdFiscaleIVA, IdTrasmittente,
-                      IscrizioneREA, Sede, StabileOrganizzazione)
+from .fattura import (
+    Allegati,
+    FullNameMixin,
+    IdFiscaleIVA,
+    IdTrasmittente,
+    IscrizioneREA,
+    Sede,
+    StabileOrganizzazione,
+)
 
 NS10 = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0"
 
@@ -9,8 +16,12 @@ class DatiTrasmissione(models.Model):
     id_trasmittente = IdTrasmittente
     progressivo_invio = fields.ProgressivoInvioField()
     formato_trasmissione = fields.StringField(length=5, choices=("FSM10",))
-    codice_destinatario = fields.StringField(null=True, min_length=6, max_length=7, default="0000000")
-    pec_destinatario = fields.StringField(null=True, min_length=8, max_length=256, xmltag="PECDestinatario")
+    codice_destinatario = fields.StringField(
+        null=True, min_length=6, max_length=7, default="0000000"
+    )
+    pec_destinatario = fields.StringField(
+        null=True, min_length=8, max_length=256, xmltag="PECDestinatario"
+    )
 
 
 class RappresentanteFiscale(FullNameMixin, models.Model):
@@ -31,9 +42,28 @@ class CedentePrestatore(FullNameMixin, models.Model):
     rappresentante_fiscale = models.ModelField(RappresentanteFiscale, null=True)
     iscrizione_rea = fields.ModelField(IscrizioneREA, null=True)
     regime_fiscale = fields.StringField(
-            length=4, choices=("RF01", "RF02", "RF04", "RF05", "RF06", "RF07",
-                               "RF08", "RF09", "RF10", "RF11", "RF12", "RF13",
-                               "RF14", "RF15", "RF16", "RF17", "RF18", "RF19"))
+        length=4,
+        choices=(
+            "RF01",
+            "RF02",
+            "RF04",
+            "RF05",
+            "RF06",
+            "RF07",
+            "RF08",
+            "RF09",
+            "RF10",
+            "RF11",
+            "RF12",
+            "RF13",
+            "RF14",
+            "RF15",
+            "RF16",
+            "RF17",
+            "RF18",
+            "RF19",
+        ),
+    )
 
 
 class IdentificativiFiscali(models.Model):
@@ -89,7 +119,9 @@ class DatiBeniServizi(models.Model):
     descrizione = fields.StringField(max_length=1000)
     importo = fields.DecimalField(max_length=15)
     dati_iva = DatiIVA
-    natura = fields.StringField(length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"))
+    natura = fields.StringField(
+        length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7")
+    )
     riferimento_normativo = fields.StringField(max_length=100, null=True)
 
 
@@ -103,13 +135,16 @@ class FatturaElettronicaSemplificata(models.Model):
     """
     Fattura elettronica semplificata
     """
+
     __xmlns__ = NS10
     fattura_elettronica_header = FatturaElettronicaHeader
     fattura_elettronica_body = fields.ModelListField(FatturaElettronicaBody, min_num=1)
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = self.get_versione()
+        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = (
+            self.get_versione()
+        )
 
     def get_versione(self):
         return "FSM10"
@@ -119,11 +154,17 @@ class FatturaElettronicaSemplificata(models.Model):
 
     def validate_model(self, validation):
         super().validate_model(validation)
-        if self.get_versione() != self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione:
+        if (
+            self.get_versione()
+            != self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione
+        ):
             validation.add_error(
-                    self.fattura_elettronica_header.dati_trasmissione._meta["formato_trasmissione"],
-                    "formato_trasmissione should be {}".format(self.get_versione()),
-                    code="00428")
+                self.fattura_elettronica_header.dati_trasmissione._meta[
+                    "formato_trasmissione"
+                ],
+                "formato_trasmissione should be {}".format(self.get_versione()),
+                code="00428",
+            )
 
     def to_xml(self, builder):
         with builder.element(self.get_xmltag(), **self.get_xmlattrs()) as b:
@@ -135,12 +176,16 @@ class FatturaElettronicaSemplificata(models.Model):
         """
         Build and return an ElementTree with the fattura in XML format
         """
-        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = self.get_versione()
+        self.fattura_elettronica_header.dati_trasmissione.formato_trasmissione = (
+            self.get_versione()
+        )
         if lxml:
             from a38.builder import LXMLBuilder
+
             builder = LXMLBuilder()
         else:
             from a38.builder import Builder
+
             builder = Builder()
         builder.default_namespace = NS10
         self.to_xml(builder)
@@ -149,9 +194,15 @@ class FatturaElettronicaSemplificata(models.Model):
     def from_etree(self, el):
         versione = el.attrib.get("versione", None)
         if versione is None:
-            raise RuntimeError("root element {} misses attribute 'versione'".format(el.tag))
+            raise RuntimeError(
+                "root element {} misses attribute 'versione'".format(el.tag)
+            )
 
         if versione != self.get_versione():
-            raise RuntimeError("root element versione is {} instead of {}".format(versione, self.get_versione()))
+            raise RuntimeError(
+                "root element versione is {} instead of {}".format(
+                    versione, self.get_versione()
+                )
+            )
 
         return super().from_etree(el)

--- a/a38/fattura_semplificata.py
+++ b/a38/fattura_semplificata.py
@@ -1,9 +1,6 @@
-from .fattura import (
-    IdTrasmittente, IdFiscaleIVA, Sede, StabileOrganizzazione, IscrizioneREA,
-    FullNameMixin, Allegati
-)
-from . import models
-from . import fields
+from . import fields, models
+from .fattura import (Allegati, FullNameMixin, IdFiscaleIVA, IdTrasmittente,
+                      IscrizioneREA, Sede, StabileOrganizzazione)
 
 NS10 = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0"
 

--- a/a38/fields.py
+++ b/a38/fields.py
@@ -1,16 +1,17 @@
-from typing import Optional, Any, TypeVar, Generic, Sequence, List
-from dateutil.parser import isoparse
+import base64
 import datetime
 import decimal
-import re
-from . import validation
-from . import builder
-from .diff import Diff
-from decimal import Decimal
-import base64
-import time
-import pytz
 import logging
+import re
+import time
+from decimal import Decimal
+from typing import Any, Generic, List, Optional, Sequence, TypeVar
+
+import pytz
+from dateutil.parser import isoparse
+
+from . import builder, validation
+from .diff import Diff
 
 log = logging.getLogger("a38.fields")
 

--- a/a38/fields.py
+++ b/a38/fields.py
@@ -32,14 +32,17 @@ class Field(Generic[T]):
 
     It does not contain the value itself.
     """
+
     # True for fields that can hold a sequence of values
     multivalue = False
 
-    def __init__(self,
-                 xmlns: Optional[str] = None,
-                 xmltag: Optional[str] = None,
-                 null: bool = False,
-                 default: Optional[T] = None):
+    def __init__(
+        self,
+        xmlns: Optional[str] = None,
+        xmltag: Optional[str] = None,
+        null: bool = False,
+        default: Optional[T] = None,
+    ):
         self.name: Optional[str] = None
         self.xmlns = xmlns
         self.xmltag = xmltag
@@ -168,6 +171,7 @@ class NotImplementedField(Field[None]):
     Field acting as a placeholder for a part of the specification that is not
     yet implemented.
     """
+
     def __init__(self, warn: bool = False, **kw):
         super().__init__(**kw)
         self.warn = warn
@@ -190,7 +194,10 @@ class ChoicesField(Field[T]):
     def validate(self, validation: "validation.Validation", value: Optional[T]):
         value = super().validate(validation, value)
         if value is not None and self.choices is not None and value not in self.choices:
-            validation.add_error(self, "{} is not a valid choice for this field".format(self.to_repr(value)))
+            validation.add_error(
+                self,
+                "{} is not a valid choice for this field".format(self.to_repr(value)),
+            )
         return value
 
 
@@ -235,9 +242,11 @@ class ListField(Field[List[T]]):
             return value
         if len(value) < self.min_num:
             validation.add_error(
-                    self,
-                    "list must have at least {} elements, but has only {}".format(
-                        self.min_num, len(value)))
+                self,
+                "list must have at least {} elements, but has only {}".format(
+                    self.min_num, len(value)
+                ),
+            )
         for idx, val in enumerate(value):
             with validation.subfield(self.name + "." + str(idx)) as sub:
                 self.field.validate(sub, val)
@@ -304,7 +313,12 @@ class IntegerField(ChoicesField[int]):
         if not self.has_value(value):
             return value
         if self.max_length is not None and len(str(value)) > self.max_length:
-            validation.add_error(self, "'{}' should be no more than {} digits long".format(value, self.max_length))
+            validation.add_error(
+                self,
+                "'{}' should be no more than {} digits long".format(
+                    value, self.max_length
+                ),
+            )
         return value
 
 
@@ -346,8 +360,11 @@ class DecimalField(ChoicesField[Decimal]):
             xml_value = self.to_str(value)
             if len(xml_value) > self.max_length:
                 validation.add_error(
-                        self,
-                        "'{}' should be no more than {} digits long".format(xml_value, self.max_length))
+                    self,
+                    "'{}' should be no more than {} digits long".format(
+                        xml_value, self.max_length
+                    ),
+                )
         return value
 
 
@@ -373,9 +390,19 @@ class StringField(ChoicesField[str]):
         if not self.has_value(value):
             return value
         if self.min_length is not None and len(value) < self.min_length:
-            validation.add_error(self, "'{}' should be at least {} characters long".format(value, self.min_length))
+            validation.add_error(
+                self,
+                "'{}' should be at least {} characters long".format(
+                    value, self.min_length
+                ),
+            )
         if self.max_length is not None and len(value) > self.max_length:
-            validation.add_error(self, "'{}' should be no more than {} characters long".format(value, self.max_length))
+            validation.add_error(
+                self,
+                "'{}' should be no more than {} characters long".format(
+                    value, self.max_length
+                ),
+            )
         return value
 
 
@@ -415,14 +442,20 @@ class DateField(ChoicesField[datetime.date]):
         if isinstance(value, str):
             mo = self.re_clean_date.match(value)
             if not mo:
-                raise ValueError("Date '{}' does not begin with YYYY-mm-dd".format(value))
+                raise ValueError(
+                    "Date '{}' does not begin with YYYY-mm-dd".format(value)
+                )
             return datetime.datetime.strptime(mo.group(1), "%Y-%m-%d").date()
         elif isinstance(value, datetime.datetime):
             return value.date()
         elif isinstance(value, datetime.date):
             return value
         else:
-            raise TypeError("'{}' is not an instance of str, datetime.date or datetime.datetime".format(repr(value)))
+            raise TypeError(
+                "'{}' is not an instance of str, datetime.date or datetime.datetime".format(
+                    repr(value)
+                )
+            )
 
     def to_jsonable(self, value):
         """
@@ -456,9 +489,15 @@ class DateTimeField(ChoicesField[datetime.datetime]):
                 return self.tz_rome.localize(value)
             return value
         elif isinstance(value, datetime.date):
-            return datetime.datetime.combine(value, datetime.time(0, 0, 0, tzinfo=self.tz_rome))
+            return datetime.datetime.combine(
+                value, datetime.time(0, 0, 0, tzinfo=self.tz_rome)
+            )
         else:
-            raise TypeError("'{}' is not an instance of str, datetime.date or datetime.datetime".format(repr(value)))
+            raise TypeError(
+                "'{}' is not an instance of str, datetime.date or datetime.datetime".format(
+                    repr(value)
+                )
+            )
 
     def to_jsonable(self, value):
         """
@@ -513,7 +552,10 @@ class ProgressivoInvioField(StringField):
             self.sequence += 1
             if self.sequence > (64 ** 3):
                 raise OverflowError(
-                        "Generated more than {} fatture per second, overflowing local counter".format(64 ** 3))
+                    "Generated more than {} fatture per second, overflowing local counter".format(
+                        64 ** 3
+                    )
+                )
 
         value = (ts << 16) + self.sequence
         return self._encode_b56(value, 10)
@@ -523,6 +565,7 @@ class ModelField(Field):
     """
     Field containing the structure from a Model
     """
+
     def __init__(self, model, **kw):
         super().__init__(**kw)
         self.model = model
@@ -608,6 +651,7 @@ class ModelListField(Field):
     """
     Field containing a list of model instances
     """
+
     multivalue = True
 
     def __init__(self, model, min_num=0, **kw):
@@ -652,8 +696,11 @@ class ModelListField(Field):
 
         if len(value) < self.min_num:
             validation.add_error(
-                    self,
-                    "list must have at least {} elements, but has only {}".format(self.min_num, len(value)))
+                self,
+                "list must have at least {} elements, but has only {}".format(
+                    self.min_num, len(value)
+                ),
+            )
 
         for idx, val in enumerate(value):
             with validation.subfield(self.name + "." + str(idx)) as sub:

--- a/a38/models.py
+++ b/a38/models.py
@@ -65,6 +65,7 @@ class Model(ModelBase, metaclass=ModelMetaclass):
     Declarative description of a data structure that can be validated and
     serialized to XML.
     """
+
     def __init__(self, *args, **kw):
         super().__init__()
         for name, value in zip(self._meta.keys(), args):
@@ -108,7 +109,9 @@ class Model(ModelBase, metaclass=ModelMetaclass):
         if value is None:
             return None
         if not isinstance(value, ModelBase):
-            raise TypeError("{} is not a Model instance".format(value.__class__.__name__))
+            raise TypeError(
+                "{} is not a Model instance".format(value.__class__.__name__)
+            )
         kw = {}
         for name, field in cls._meta.items():
             kw[name] = getattr(value, name, None)
@@ -245,9 +248,13 @@ class Model(ModelBase, metaclass=ModelMetaclass):
 
     def from_etree(self, el):
         if el.tag != self.get_xmltag():
-            raise RuntimeError("element is {} instead of {}".format(el.tag, self.get_xmltag()))
+            raise RuntimeError(
+                "element is {} instead of {}".format(el.tag, self.get_xmltag())
+            )
 
-        tag_map = {field.get_xmltag(): (name, field) for name, field in self._meta.items()}
+        tag_map = {
+            field.get_xmltag(): (name, field) for name, field in self._meta.items()
+        }
 
         # Group values by tag
         by_name = defaultdict(list)
@@ -255,7 +262,9 @@ class Model(ModelBase, metaclass=ModelMetaclass):
             try:
                 name, field = tag_map[child.tag]
             except KeyError:
-                raise RuntimeError("found unexpected element {} in {}".format(child.tag, el.tag))
+                raise RuntimeError(
+                    "found unexpected element {} in {}".format(child.tag, el.tag)
+                )
 
             by_name[name].append(child)
 
@@ -265,8 +274,10 @@ class Model(ModelBase, metaclass=ModelMetaclass):
                 setattr(self, name, field.from_etree(elements))
             elif len(elements) != 1:
                 raise RuntimeError(
-                        "found {} {} elements in {} instead of just 1".format(
-                            len(elements), child.tag, el.tag))
+                    "found {} {} elements in {} instead of just 1".format(
+                        len(elements), child.tag, el.tag
+                    )
+                )
             else:
                 setattr(self, name, field.from_etree(elements[0]))
 

--- a/a38/models.py
+++ b/a38/models.py
@@ -1,7 +1,8 @@
-from typing import Dict, Any, Optional, Tuple
+from collections import OrderedDict, defaultdict
+from typing import Any, Dict, Optional, Tuple
+
 from .fields import Field, ModelField
 from .validation import Validation
-from collections import OrderedDict, defaultdict
 
 
 class ModelBase:

--- a/a38/render.py
+++ b/a38/render.py
@@ -5,12 +5,14 @@ from typing import Optional
 
 try:
     import lxml.etree
+
     HAVE_LXML = True
 except ModuleNotFoundError:
     HAVE_LXML = False
 
 
 if HAVE_LXML:
+
     class XSLTTransform:
         def __init__(self, xslt):
             parsed_xslt = lxml.etree.parse(xslt)
@@ -32,7 +34,11 @@ if HAVE_LXML:
             # We need to specifically use --extended-help, because --help does
             # not always document --enable-local-file-access
             verifyLocalAccessToFileOption = subprocess.run(
-                    [wkhtmltopdf, "--extended-help"], stdin=subprocess.DEVNULL, text=True, capture_output=True)
+                [wkhtmltopdf, "--extended-help"],
+                stdin=subprocess.DEVNULL,
+                text=True,
+                capture_output=True,
+            )
             return "--enable-local-file-access" in verifyLocalAccessToFileOption.stdout
 
         def to_pdf(self, wkhtmltopdf: str, f, output_file: Optional[str] = None):
@@ -57,12 +63,16 @@ if HAVE_LXML:
                 if self._requires_enable_local_file_access(wkhtmltopdf):
                     cmdLine.insert(1, "--enable-local-file-access")
 
-                res = subprocess.run(cmdLine, stdin=subprocess.DEVNULL, capture_output=True)
+                res = subprocess.run(
+                    cmdLine, stdin=subprocess.DEVNULL, capture_output=True
+                )
 
                 if res.returncode != 0:
                     raise RuntimeError(
-                            "{0} exited with error {1}: stderr: {2!r}".format(
-                                wkhtmltopdf, res.returncode, res.stderr))
+                        "{0} exited with error {1}: stderr: {2!r}".format(
+                            wkhtmltopdf, res.returncode, res.stderr
+                        )
+                    )
 
                 if output_file == "-":
                     return res.stdout

--- a/a38/render.py
+++ b/a38/render.py
@@ -1,7 +1,8 @@
-from typing import Optional
-import tempfile
-import subprocess
 import os
+import subprocess
+import tempfile
+from typing import Optional
+
 try:
     import lxml.etree
     HAVE_LXML = True

--- a/a38/traversal.py
+++ b/a38/traversal.py
@@ -1,5 +1,6 @@
-from typing import Optional
 from contextlib import contextmanager
+from typing import Optional
+
 from . import fields
 
 

--- a/a38/trustedlist.py
+++ b/a38/trustedlist.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict
 
+import cryptography.x509
+
 from . import fields, models
 
 log = logging.getLogger("__name__")
@@ -167,7 +169,7 @@ def load_url(url: str):
     return auto_from_etree(root)
 
 
-def load_certs() -> Dict[str, "cryptography.x509.Certificate"]:
+def load_certs() -> Dict[str, cryptography.x509.Certificate]:
     """
     Download trusted list certificates for Italy, parse them and return a dict
     mapping certificate names good for use as file names to cryptography.x509

--- a/a38/trustedlist.py
+++ b/a38/trustedlist.py
@@ -1,13 +1,13 @@
-from typing import Dict
-import re
-from collections import defaultdict
-import xml.etree.ElementTree as ET
-import logging
 import base64
+import logging
+import re
 import subprocess
+import xml.etree.ElementTree as ET
+from collections import defaultdict
 from pathlib import Path
-from . import models
-from . import fields
+from typing import Dict
+
+from . import fields, models
 
 log = logging.getLogger("__name__")
 

--- a/a38/validation.py
+++ b/a38/validation.py
@@ -5,7 +5,9 @@ from .traversal import Annotation, Traversal
 
 
 class ValidationError(Annotation):
-    def __init__(self, prefix: Optional[str], field: "fields.Field", msg: str, code: str = None):
+    def __init__(
+        self, prefix: Optional[str], field: "fields.Field", msg: str, code: str = None
+    ):
         self.prefix = prefix
         self.field = field
         self.msg = msg
@@ -22,10 +24,12 @@ Fields = Union["fields.Field", Sequence["fields.Field"]]
 
 
 class Validation(Traversal):
-    def __init__(self,
-                 prefix: Optional[str] = None,
-                 warnings: Optional[List[ValidationError]] = None,
-                 errors: Optional[List[ValidationError]] = None):
+    def __init__(
+        self,
+        prefix: Optional[str] = None,
+        warnings: Optional[List[ValidationError]] = None,
+        errors: Optional[List[ValidationError]] = None,
+    ):
         super().__init__(prefix)
         self.warnings: List[ValidationError]
         self.errors: List[ValidationError]

--- a/a38/validation.py
+++ b/a38/validation.py
@@ -1,6 +1,7 @@
-from typing import Optional, List, Sequence, Union
-from .traversal import Annotation, Traversal
+from typing import List, Optional, Sequence, Union
+
 from . import fields
+from .traversal import Annotation, Traversal
 
 
 class ValidationError(Annotation):

--- a/requirements-devops.txt
+++ b/requirements-devops.txt
@@ -1,0 +1,6 @@
+isort
+black
+flake8
+pylint
+pytype
+bandit

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@ from setuptools import setup
 with open("README.md", "r") as fp:
     long_description = fp.read()
 
+
 def parse_requirements(filename):
-    lineiter = (line.strip() for line in open(filename))
-    return [line for line in lineiter if line and not line.startswith("#")]
+    line_iter = (line.strip() for line in open(filename))
+    return [line for line in line_iter if line and not line.startswith("#")]
+
 
 setup(
     name="a38",

--- a/tests/test_fattura.py
+++ b/tests/test_fattura.py
@@ -19,41 +19,59 @@ class TestAnagrafica(TestFatturaMixin, TestCase):
     def test_validation(self):
         a = a38.Anagrafica()
 
-        self.assert_validates(a, errors=[
-            'nome: nome and cognome, or denominazione, must be set',
-            'cognome: nome and cognome, or denominazione, must be set',
-            'denominazione: nome and cognome, or denominazione, must be set',
-        ])
+        self.assert_validates(
+            a,
+            errors=[
+                "nome: nome and cognome, or denominazione, must be set",
+                "cognome: nome and cognome, or denominazione, must be set",
+                "denominazione: nome and cognome, or denominazione, must be set",
+            ],
+        )
 
         a.nome = "Test"
-        self.assert_validates(a, errors=[
-            "cognome: nome and cognome must both be set if denominazione is empty",
-        ])
+        self.assert_validates(
+            a,
+            errors=[
+                "cognome: nome and cognome must both be set if denominazione is empty",
+            ],
+        )
 
         a.cognome = "Test1"
         self.assert_validates(a)
 
         a.nome = None
-        self.assert_validates(a, errors=[
-            "nome: nome and cognome must both be set if denominazione is empty",
-        ])
+        self.assert_validates(
+            a,
+            errors=[
+                "nome: nome and cognome must both be set if denominazione is empty",
+            ],
+        )
 
         a.denominazione = "Test Test1"
-        self.assert_validates(a, errors=[
-            "cognome: cognome must not be set if denominazione is not empty",
-        ])
+        self.assert_validates(
+            a,
+            errors=[
+                "cognome: cognome must not be set if denominazione is not empty",
+            ],
+        )
 
         a.denominazione = "Test Test1"
         a.nome = "Test"
-        self.assert_validates(a, errors=[
-            "nome: nome and cognome must not be set if denominazione is not empty",
-            "cognome: nome and cognome must not be set if denominazione is not empty",
-        ])
+        self.assert_validates(
+            a,
+            errors=[
+                "nome: nome and cognome must not be set if denominazione is not empty",
+                "cognome: nome and cognome must not be set if denominazione is not empty",
+            ],
+        )
 
         a.cognome = None
-        self.assert_validates(a, errors=[
-            "nome: nome must not be set if denominazione is not empty",
-        ])
+        self.assert_validates(
+            a,
+            errors=[
+                "nome: nome must not be set if denominazione is not empty",
+            ],
+        )
 
         a.nome = None
         self.assert_validates(a)
@@ -62,29 +80,38 @@ class TestAnagrafica(TestFatturaMixin, TestCase):
 class TestDatiTrasmissione(TestFatturaMixin, TestCase):
     def test_validation(self):
         dt = a38.DatiTrasmissione(
-                a38.IdTrasmittente("ID", "1234567890"),
-                "12345", "FPR12")
+            a38.IdTrasmittente("ID", "1234567890"), "12345", "FPR12"
+        )
 
-        self.assert_validates(dt, errors=[
-            # "codice_destinatario: one of codice_destinatario or pec_destinatario must be set",
-            # "pec_destinatario: one of codice_destinatario or pec_destinatario must be set",
-            "codice_destinatario: [00426] pec_destinatario has no value while codice_destinatario has value 0000000",
-            "pec_destinatario: [00426] pec_destinatario has no value while codice_destinatario has value 0000000",
-        ])
+        self.assert_validates(
+            dt,
+            errors=[
+                # "codice_destinatario: one of codice_destinatario or pec_destinatario must be set",
+                # "pec_destinatario: one of codice_destinatario or pec_destinatario must be set",
+                "codice_destinatario: [00426] pec_destinatario has no value while codice_destinatario has value 0000000",
+                "pec_destinatario: [00426] pec_destinatario has no value while codice_destinatario has value 0000000",
+            ],
+        )
 
         dt.codice_destinatario = "FUFUFU"
-        self.assert_validates(dt, errors=[
-            "codice_destinatario: [00427] codice_destinatario has 6 characters on a Fattura Privati",
-        ])
+        self.assert_validates(
+            dt,
+            errors=[
+                "codice_destinatario: [00427] codice_destinatario has 6 characters on a Fattura Privati",
+            ],
+        )
 
         dt.codice_destinatario = "FUFUFUF"
         self.assert_validates(dt)
 
         dt.pec_destinatario = "local_part@example.org"
-        self.assert_validates(dt, errors=[
-            "codice_destinatario: [00426] pec_destinatario has value while codice_destinatario has value 0000000",
-            "pec_destinatario: [00426] pec_destinatario has value while codice_destinatario has value 0000000",
-        ])
+        self.assert_validates(
+            dt,
+            errors=[
+                "codice_destinatario: [00426] pec_destinatario has value while codice_destinatario has value 0000000",
+                "pec_destinatario: [00426] pec_destinatario has value while codice_destinatario has value 0000000",
+            ],
+        )
 
         dt.codice_destinatario = None
         self.assert_validates(dt)
@@ -93,44 +120,138 @@ class TestDatiTrasmissione(TestFatturaMixin, TestCase):
 class TestDatiBeniServizi(TestFatturaMixin, TestCase):
     def test_add_dettaglio_linee(self):
         o = a38.DatiBeniServizi()
-        o.add_dettaglio_linee(descrizione="Line 1", quantita=2, unita_misura="m²", prezzo_unitario=7, aliquota_iva=22)
-        o.add_dettaglio_linee(descrizione="Line 2", quantita=1, unita_misura="A", prezzo_unitario="0.4", aliquota_iva=22)
+        o.add_dettaglio_linee(
+            descrizione="Line 1",
+            quantita=2,
+            unita_misura="m²",
+            prezzo_unitario=7,
+            aliquota_iva=22,
+        )
+        o.add_dettaglio_linee(
+            descrizione="Line 2",
+            quantita=1,
+            unita_misura="A",
+            prezzo_unitario="0.4",
+            aliquota_iva=22,
+        )
         self.assertEqual(len(o.dettaglio_linee), 2)
-        self.assertEqual(o.dettaglio_linee[0], a38.DettaglioLinee(
-            numero_linea=1, descrizione="Line 1", quantita=2, unita_misura="m²",
-            prezzo_unitario=7, prezzo_totale=14, aliquota_iva=22))
-        self.assertEqual(o.dettaglio_linee[1], a38.DettaglioLinee(
-            numero_linea=2, descrizione="Line 2", quantita=1, unita_misura="A",
-            prezzo_unitario="0.4", prezzo_totale="0.4", aliquota_iva=22))
+        self.assertEqual(
+            o.dettaglio_linee[0],
+            a38.DettaglioLinee(
+                numero_linea=1,
+                descrizione="Line 1",
+                quantita=2,
+                unita_misura="m²",
+                prezzo_unitario=7,
+                prezzo_totale=14,
+                aliquota_iva=22,
+            ),
+        )
+        self.assertEqual(
+            o.dettaglio_linee[1],
+            a38.DettaglioLinee(
+                numero_linea=2,
+                descrizione="Line 2",
+                quantita=1,
+                unita_misura="A",
+                prezzo_unitario="0.4",
+                prezzo_totale="0.4",
+                aliquota_iva=22,
+            ),
+        )
 
     def test_add_dettaglio_linee_without_quantita(self):
         o = a38.DatiBeniServizi()
         o.add_dettaglio_linee(descrizione="Line 1", prezzo_unitario=7, aliquota_iva=22)
         self.assertEqual(len(o.dettaglio_linee), 1)
-        self.assertEqual(o.dettaglio_linee[0], a38.DettaglioLinee(1, descrizione="Line 1", prezzo_unitario=7, prezzo_totale=7, aliquota_iva=22))
+        self.assertEqual(
+            o.dettaglio_linee[0],
+            a38.DettaglioLinee(
+                1,
+                descrizione="Line 1",
+                prezzo_unitario=7,
+                prezzo_totale=7,
+                aliquota_iva=22,
+            ),
+        )
 
     def test_build_dati_riepilogo(self):
         o = a38.DatiBeniServizi()
-        o.add_dettaglio_linee(descrizione="Line 1", quantita=2, unita_misura="m²", prezzo_unitario=7, aliquota_iva=22)
-        o.add_dettaglio_linee(descrizione="Line 2", quantita=1, unita_misura="A", prezzo_unitario="0.4", aliquota_iva=22)
-        o.add_dettaglio_linee(descrizione="Line 3", quantita="3.5", unita_misura="A", prezzo_unitario="0.5", aliquota_iva=10)
+        o.add_dettaglio_linee(
+            descrizione="Line 1",
+            quantita=2,
+            unita_misura="m²",
+            prezzo_unitario=7,
+            aliquota_iva=22,
+        )
+        o.add_dettaglio_linee(
+            descrizione="Line 2",
+            quantita=1,
+            unita_misura="A",
+            prezzo_unitario="0.4",
+            aliquota_iva=22,
+        )
+        o.add_dettaglio_linee(
+            descrizione="Line 3",
+            quantita="3.5",
+            unita_misura="A",
+            prezzo_unitario="0.5",
+            aliquota_iva=10,
+        )
         o.build_dati_riepilogo()
 
         self.assertEqual(len(o.dati_riepilogo), 2)
-        self.assertEqual(o.dati_riepilogo[0], a38.DatiRiepilogo(aliquota_iva="10", imponibile_importo="1.75",  imposta="0.175", esigibilita_iva="I"))
-        self.assertEqual(o.dati_riepilogo[1], a38.DatiRiepilogo(aliquota_iva="22", imponibile_importo="14.40", imposta="3.168", esigibilita_iva="I"))
+        self.assertEqual(
+            o.dati_riepilogo[0],
+            a38.DatiRiepilogo(
+                aliquota_iva="10",
+                imponibile_importo="1.75",
+                imposta="0.175",
+                esigibilita_iva="I",
+            ),
+        )
+        self.assertEqual(
+            o.dati_riepilogo[1],
+            a38.DatiRiepilogo(
+                aliquota_iva="22",
+                imponibile_importo="14.40",
+                imposta="3.168",
+                esigibilita_iva="I",
+            ),
+        )
 
 
 class TestFatturaElettronicaBody(TestFatturaMixin, TestCase):
     def test_build_importo_totale_documento(self):
         o = a38.FatturaElettronicaBody()
-        o.dati_beni_servizi.add_dettaglio_linee(descrizione="Line 1", quantita=2, unita_misura="m²", prezzo_unitario=7, aliquota_iva=22)
-        o.dati_beni_servizi.add_dettaglio_linee(descrizione="Line 2", quantita=1, unita_misura="A", prezzo_unitario="0.4", aliquota_iva=22)
-        o.dati_beni_servizi.add_dettaglio_linee(descrizione="Line 3", quantita="3.5", unita_misura="A", prezzo_unitario="0.5", aliquota_iva=10)
+        o.dati_beni_servizi.add_dettaglio_linee(
+            descrizione="Line 1",
+            quantita=2,
+            unita_misura="m²",
+            prezzo_unitario=7,
+            aliquota_iva=22,
+        )
+        o.dati_beni_servizi.add_dettaglio_linee(
+            descrizione="Line 2",
+            quantita=1,
+            unita_misura="A",
+            prezzo_unitario="0.4",
+            aliquota_iva=22,
+        )
+        o.dati_beni_servizi.add_dettaglio_linee(
+            descrizione="Line 3",
+            quantita="3.5",
+            unita_misura="A",
+            prezzo_unitario="0.5",
+            aliquota_iva=10,
+        )
         o.dati_beni_servizi.build_dati_riepilogo()
         o.build_importo_totale_documento()
 
-        self.assertEqual(o.dati_generali.dati_generali_documento.importo_totale_documento, Decimal("19.493"))
+        self.assertEqual(
+            o.dati_generali.dati_generali_documento.importo_totale_documento,
+            Decimal("19.493"),
+        )
 
 
 class TestFatturaPrivati12(TestFatturaMixin, TestCase):
@@ -142,7 +263,14 @@ class TestFatturaPrivati12(TestFatturaMixin, TestCase):
                 anagrafica=a38.Anagrafica(denominazione="Test User"),
                 regime_fiscale="RF01",
             ),
-            a38.Sede(indirizzo="via Monferrato", numero_civico="1", cap="50100", comune="Firenze", provincia="FI", nazione="IT"),
+            a38.Sede(
+                indirizzo="via Monferrato",
+                numero_civico="1",
+                cap="50100",
+                comune="Firenze",
+                provincia="FI",
+                nazione="IT",
+            ),
             iscrizione_rea=a38.IscrizioneREA(
                 ufficio="FI",
                 numero_rea="123456",
@@ -156,7 +284,14 @@ class TestFatturaPrivati12(TestFatturaMixin, TestCase):
                 a38.IdFiscaleIVA("IT", "76543210987"),
                 anagrafica=a38.Anagrafica(denominazione="A Company SRL"),
             ),
-            a38.Sede(indirizzo="via Langhe", numero_civico="1", cap="50142", comune="Firenze", provincia="FI", nazione="IT"),
+            a38.Sede(
+                indirizzo="via Langhe",
+                numero_civico="1",
+                cap="50142",
+                comune="Firenze",
+                provincia="FI",
+                nazione="IT",
+            ),
         )
 
         f = a38.FatturaPrivati12()
@@ -177,12 +312,20 @@ class TestFatturaPrivati12(TestFatturaMixin, TestCase):
         )
 
         body.dati_beni_servizi.add_dettaglio_linee(
-                descrizione="Test item", quantita=2, unita_misura="kg",
-                prezzo_unitario="25.50", aliquota_iva="22.00")
+            descrizione="Test item",
+            quantita=2,
+            unita_misura="kg",
+            prezzo_unitario="25.50",
+            aliquota_iva="22.00",
+        )
 
         body.dati_beni_servizi.add_dettaglio_linee(
-                descrizione="Other item", quantita=1, unita_misura="kg",
-                prezzo_unitario="15.50", aliquota_iva="22.00")
+            descrizione="Other item",
+            quantita=1,
+            unita_misura="kg",
+            prezzo_unitario="15.50",
+            aliquota_iva="22.00",
+        )
 
         body.dati_beni_servizi.build_dati_riepilogo()
         body.build_importo_totale_documento()
@@ -198,22 +341,30 @@ class TestFatturaPrivati12(TestFatturaMixin, TestCase):
 
     def test_validate(self):
         f = self.build_sample()
-        self.assertEqual(f.fattura_elettronica_header.dati_trasmissione.formato_trasmissione, "FPR12")
+        self.assertEqual(
+            f.fattura_elettronica_header.dati_trasmissione.formato_trasmissione, "FPR12"
+        )
         self.assert_validates(f)
 
     def test_serialize(self):
         f = self.build_sample()
-        self.assertEqual(f.fattura_elettronica_header.dati_trasmissione.formato_trasmissione, "FPR12")
+        self.assertEqual(
+            f.fattura_elettronica_header.dati_trasmissione.formato_trasmissione, "FPR12"
+        )
         tree = f.build_etree()
         with io.StringIO() as out:
             tree.write(out, encoding="unicode")
             xml = out.getvalue()
 
-        self.assertIn('<ns0:FatturaElettronica xmlns:ns0="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">', xml)
-        self.assertIn('<FormatoTrasmissione>FPR12</FormatoTrasmissione>', xml)
+        self.assertIn(
+            '<ns0:FatturaElettronica xmlns:ns0="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">',
+            xml,
+        )
+        self.assertIn("<FormatoTrasmissione>FPR12</FormatoTrasmissione>", xml)
 
     def test_serialize_lxml(self):
         from a38 import builder
+
         if not builder.HAVE_LXML:
             raise SkipTest("lxml is not available")
 
@@ -223,8 +374,11 @@ class TestFatturaPrivati12(TestFatturaMixin, TestCase):
             tree.write(out)
             xml = out.getvalue()
 
-        self.assertIn(b'<ns0:FatturaElettronica xmlns:ns0="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">', xml)
-        self.assertIn(b'<FormatoTrasmissione>FPR12</FormatoTrasmissione>', xml)
+        self.assertIn(
+            b'<ns0:FatturaElettronica xmlns:ns0="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">',
+            xml,
+        )
+        self.assertIn(b"<FormatoTrasmissione>FPR12</FormatoTrasmissione>", xml)
 
     def test_to_python(self):
         f = self.build_sample()
@@ -260,5 +414,6 @@ class TestFatturaPrivati12(TestFatturaMixin, TestCase):
 class TestSamples(TestFatturaMixin, TestCase):
     def test_parse_dati_trasporto(self):
         import xml.etree.ElementTree as ET
+
         tree = ET.parse("tests/data/dati_trasporto.xml")
         a38.auto_from_etree(tree.getroot())

--- a/tests/test_fattura.py
+++ b/tests/test_fattura.py
@@ -1,9 +1,10 @@
-from unittest import TestCase, SkipTest
-import a38.fattura as a38
-from a38 import validation
-from decimal import Decimal
 import datetime
 import io
+from decimal import Decimal
+from unittest import SkipTest, TestCase
+
+import a38.fattura as a38
+from a38 import validation
 
 
 class TestFatturaMixin:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -31,9 +31,14 @@ class FieldTestMixin:
         f = self.get_field()
 
         # Validating a field with null=False raises an error
-        self.assert_validates(f, None, result=None, errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            None,
+            result=None,
+            errors=[
+                "sample: missing value",
+            ],
+        )
 
         # But null values are tolerated outside validation, while structures
         # are being filled
@@ -96,7 +101,9 @@ class FieldTestMixin:
         res = Diff()
         field.diff(res, first, second)
         if res.differences:
-            self.assertEqual([(d.prefix, d.field, d.first, d.second) for d in res.differences], [])
+            self.assertEqual(
+                [(d.prefix, d.field, d.first, d.second) for d in res.differences], []
+            )
 
     def assert_diff(self, field, first, second, expected):
         """
@@ -116,9 +123,17 @@ class FieldTestMixin:
         self.assert_diff(field, None, first, ["sample: first is not set"])
         self.assert_diff(field, second, None, ["sample: second is not set"])
         self.assert_diff(field, None, second, ["sample: first is not set"])
-        self.assert_diff(field, first, second, ["sample: first: {}, second: {}".format(
-            field.to_str(field.clean_value(first)),
-            field.to_str(field.clean_value(second)))])
+        self.assert_diff(
+            field,
+            first,
+            second,
+            [
+                "sample: first: {}, second: {}".format(
+                    field.to_str(field.clean_value(first)),
+                    field.to_str(field.clean_value(second)),
+                )
+            ],
+        )
 
     def to_xml(self, field, value):
         """
@@ -161,23 +176,43 @@ class TestStringField(FieldTestMixin, TestCase):
 
     def test_length(self):
         f = self.get_field(length=3)
-        self.assert_validates(f, "va", result="va", errors=[
-            "sample: 'va' should be at least 3 characters long",
-        ])
-        self.assert_validates(f, "valu", result="valu", errors=[
-            "sample: 'valu' should be no more than 3 characters long",
-        ])
-        self.assert_validates(f, 1.15, result="1.15", errors=[
-            "sample: '1.15' should be no more than 3 characters long",
-        ])
+        self.assert_validates(
+            f,
+            "va",
+            result="va",
+            errors=[
+                "sample: 'va' should be at least 3 characters long",
+            ],
+        )
+        self.assert_validates(
+            f,
+            "valu",
+            result="valu",
+            errors=[
+                "sample: 'valu' should be no more than 3 characters long",
+            ],
+        )
+        self.assert_validates(
+            f,
+            1.15,
+            result="1.15",
+            errors=[
+                "sample: '1.15' should be no more than 3 characters long",
+            ],
+        )
         self.assert_validates(f, "val", result="val")
         self.assert_validates(f, 1.2, result="1.2")
 
     def test_min_length(self):
         f = self.get_field(min_length=3)
-        self.assert_validates(f, "va", result="va", errors=[
-            "sample: 'va' should be at least 3 characters long",
-        ])
+        self.assert_validates(
+            f,
+            "va",
+            result="va",
+            errors=[
+                "sample: 'va' should be at least 3 characters long",
+            ],
+        )
         self.assert_validates(f, "valu", result="valu")
         self.assert_validates(f, "val", result="val")
         self.assert_validates(f, 1.2, result="1.2")
@@ -188,35 +223,65 @@ class TestStringField(FieldTestMixin, TestCase):
         self.assert_validates(f, "v", result="v")
         self.assert_validates(f, "va", result="va")
         self.assert_validates(f, "val", result="val")
-        self.assert_validates(f, "valu", result="valu", errors=[
-            "sample: 'valu' should be no more than 3 characters long",
-        ])
+        self.assert_validates(
+            f,
+            "valu",
+            result="valu",
+            errors=[
+                "sample: 'valu' should be no more than 3 characters long",
+            ],
+        )
 
     def test_choices(self):
         f = self.get_field(choices=("A", "B"))
         self.assert_validates(f, "A", result="A")
         self.assert_validates(f, "B", result="B")
-        self.assert_validates(f, "C", result="C", errors=[
-            "sample: 'C' is not a valid choice for this field",
-        ])
-        self.assert_validates(f, "a", result="a", errors=[
-            "sample: 'a' is not a valid choice for this field",
-        ])
-        self.assert_validates(f, None, result=None, errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            "C",
+            result="C",
+            errors=[
+                "sample: 'C' is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            "a",
+            result="a",
+            errors=[
+                "sample: 'a' is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            None,
+            result=None,
+            errors=[
+                "sample: missing value",
+            ],
+        )
 
     def test_choices_nullable(self):
         f = self.get_field(choices=("A", "B"), null=True)
         self.assert_validates(f, "A", result="A")
         self.assert_validates(f, "B", result="B")
         self.assert_validates(f, None, result=None)
-        self.assert_validates(f, "C", result="C", errors=[
-            "sample: 'C' is not a valid choice for this field",
-        ])
-        self.assert_validates(f, "a", result="a", errors=[
-            "sample: 'a' is not a valid choice for this field",
-        ])
+        self.assert_validates(
+            f,
+            "C",
+            result="C",
+            errors=[
+                "sample: 'C' is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            "a",
+            result="a",
+            errors=[
+                "sample: 'a' is not a valid choice for this field",
+            ],
+        )
 
     def test_to_python(self):
         f = self.get_field()
@@ -244,9 +309,14 @@ class TestIntegerField(FieldTestMixin, TestCase):
         self.assert_validates(f, 12, result=12)
         self.assert_validates(f, "12", result=12)
         self.assert_validates(f, 12.3, result=12)
-        self.assert_validates(f, "foo", result="foo", errors=[
-            "sample: invalid literal for int() with base 10: 'foo'",
-        ])
+        self.assert_validates(
+            f,
+            "foo",
+            result="foo",
+            errors=[
+                "sample: invalid literal for int() with base 10: 'foo'",
+            ],
+        )
 
     def test_default(self):
         f = self.get_field(default=7)
@@ -258,28 +328,48 @@ class TestIntegerField(FieldTestMixin, TestCase):
         self.assert_validates(f, 1, result=1)
         self.assert_validates(f, 12, result=12)
         self.assert_validates(f, 123, result=123)
-        self.assert_validates(f, 1234, result=1234, errors=[
-            "sample: '1234' should be no more than 3 digits long",
-        ])
+        self.assert_validates(
+            f,
+            1234,
+            result=1234,
+            errors=[
+                "sample: '1234' should be no more than 3 digits long",
+            ],
+        )
 
     def test_choices(self):
         f = self.get_field(choices=(1, 2))
         self.assert_validates(f, 1, result=1)
         self.assert_validates(f, 2, result=2)
-        self.assert_validates(f, 3, result=3, errors=[
-            "sample: 3 is not a valid choice for this field",
-        ])
-        self.assert_validates(f, None, result=None, errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            3,
+            result=3,
+            errors=[
+                "sample: 3 is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            None,
+            result=None,
+            errors=[
+                "sample: missing value",
+            ],
+        )
 
     def test_choices_nullable(self):
         f = self.get_field(choices=(1, 2), null=True)
         self.assert_validates(f, 1, result=1)
         self.assert_validates(f, 2, result=2)
-        self.assert_validates(f, 3, result=3, errors=[
-            "sample: 3 is not a valid choice for this field",
-        ])
+        self.assert_validates(
+            f,
+            3,
+            result=3,
+            errors=[
+                "sample: 3 is not a valid choice for this field",
+            ],
+        )
         self.assert_validates(f, None, result=None)
 
     def test_to_python(self):
@@ -306,9 +396,14 @@ class TestDecimalField(FieldTestMixin, TestCase):
         self.assert_validates(f, 12, result=Decimal("12.00"))
         self.assert_validates(f, "12", result=Decimal("12.00"))
         self.assert_validates(f, "12.345", result=Decimal("12.345"))
-        self.assert_validates(f, "foo", result="foo", errors=[
-            "sample: 'foo' cannot be converted to Decimal",
-        ])
+        self.assert_validates(
+            f,
+            "foo",
+            result="foo",
+            errors=[
+                "sample: 'foo' cannot be converted to Decimal",
+            ],
+        )
 
     def test_default(self):
         f = self.get_field(default="7.0")
@@ -319,21 +414,36 @@ class TestDecimalField(FieldTestMixin, TestCase):
         f = self.get_field(max_length=4)
         self.assert_validates(f, 1, result=Decimal("1.00"))
         # 12 becomes 12.00 which is 5 characters long on a max_length of 4
-        self.assert_validates(f, 12, result=Decimal("12.00"), errors=[
-            "sample: '12.00' should be no more than 4 digits long",
-        ])
+        self.assert_validates(
+            f,
+            12,
+            result=Decimal("12.00"),
+            errors=[
+                "sample: '12.00' should be no more than 4 digits long",
+            ],
+        )
 
     def test_choices(self):
         f = self.get_field(choices=("1.1", "2.2"))
         self.assert_validates(f, "1.1", result=Decimal("1.1"))
         self.assert_validates(f, Decimal("2.2"), result=Decimal("2.2"))
         # 1.1 does not have an exact decimal representation
-        self.assert_validates(f, 1.1, result=Decimal("1.100000000000000088817841970012523233890533447265625"), errors=[
-            "sample: Decimal('1.100000000000000088817841970012523233890533447265625') is not a valid choice for this field",
-        ])
-        self.assert_validates(f, None, result=None, errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            1.1,
+            result=Decimal("1.100000000000000088817841970012523233890533447265625"),
+            errors=[
+                "sample: Decimal('1.100000000000000088817841970012523233890533447265625') is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            None,
+            result=None,
+            errors=[
+                "sample: missing value",
+            ],
+        )
 
     def test_choices_nullable(self):
         f = self.get_field(choices=("1.1", "2.2"), null=True)
@@ -342,9 +452,14 @@ class TestDecimalField(FieldTestMixin, TestCase):
         self.assert_validates(f, None, result=None)
         # 1.1 does not have an exact decimal representation
         dec11 = Decimal(1.1)
-        self.assert_validates(f, 1.1, result=dec11, errors=[
-            "sample: {!r} is not a valid choice for this field".format(dec11),
-        ])
+        self.assert_validates(
+            f,
+            1.1,
+            result=dec11,
+            errors=[
+                "sample: {!r} is not a valid choice for this field".format(dec11),
+            ],
+        )
 
     def test_to_python(self):
         f = self.get_field()
@@ -367,15 +482,29 @@ class TestDateField(FieldTestMixin, TestCase):
 
     def test_value(self):
         f = self.get_field()
-        self.assert_validates(f, datetime.date(2019, 1, 2), result=datetime.date(2019, 1, 2))
+        self.assert_validates(
+            f, datetime.date(2019, 1, 2), result=datetime.date(2019, 1, 2)
+        )
         self.assert_validates(f, "2019-01-02", result=datetime.date(2019, 1, 2))
-        self.assert_validates(f, datetime.datetime(2019, 1, 2, 12, 30), result=datetime.date(2019, 1, 2))
-        self.assert_validates(f, "foo", result="foo", errors=[
-            "sample: Date 'foo' does not begin with YYYY-mm-dd",
-        ])
-        self.assert_validates(f, [123], result=[123], errors=[
-            "sample: '[123]' is not an instance of str, datetime.date or datetime.datetime",
-        ])
+        self.assert_validates(
+            f, datetime.datetime(2019, 1, 2, 12, 30), result=datetime.date(2019, 1, 2)
+        )
+        self.assert_validates(
+            f,
+            "foo",
+            result="foo",
+            errors=[
+                "sample: Date 'foo' does not begin with YYYY-mm-dd",
+            ],
+        )
+        self.assert_validates(
+            f,
+            [123],
+            result=[123],
+            errors=[
+                "sample: '[123]' is not an instance of str, datetime.date or datetime.datetime",
+            ],
+        )
 
     def test_default(self):
         f = self.get_field(default="2019-01-02")
@@ -386,20 +515,35 @@ class TestDateField(FieldTestMixin, TestCase):
         f = self.get_field(choices=("2019-01-01", "2019-01-02"))
         self.assert_validates(f, "2019-01-01", result=datetime.date(2019, 1, 1))
         self.assert_validates(f, "2019-01-02", result=datetime.date(2019, 1, 2))
-        self.assert_validates(f, "2019-01-03", result=datetime.date(2019, 1, 3), errors=[
-            "sample: datetime.date(2019, 1, 3) is not a valid choice for this field",
-        ])
-        self.assert_validates(f, None, result=None, errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            "2019-01-03",
+            result=datetime.date(2019, 1, 3),
+            errors=[
+                "sample: datetime.date(2019, 1, 3) is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            None,
+            result=None,
+            errors=[
+                "sample: missing value",
+            ],
+        )
 
     def test_choices_nullable(self):
         f = self.get_field(choices=("2019-01-01", "2019-01-02"), null=True)
         self.assert_validates(f, "2019-01-01", result=datetime.date(2019, 1, 1))
         self.assert_validates(f, "2019-01-02", result=datetime.date(2019, 1, 2))
-        self.assert_validates(f, "2019-01-03", result=datetime.date(2019, 1, 3), errors=[
-            "sample: datetime.date(2019, 1, 3) is not a valid choice for this field",
-        ])
+        self.assert_validates(
+            f,
+            "2019-01-03",
+            result=datetime.date(2019, 1, 3),
+            errors=[
+                "sample: datetime.date(2019, 1, 3) is not a valid choice for this field",
+            ],
+        )
         self.assert_validates(f, None, result=None)
 
     def test_to_python(self):
@@ -415,8 +559,13 @@ class TestDateField(FieldTestMixin, TestCase):
 
     def test_xml(self):
         f = self.get_field(null=True)
-        self.assertEqual(self.to_xml(f, datetime.date(2019, 1, 2)), "<T><Sample>2019-01-02</Sample></T>")
-        self.assertEqual(self.to_xml(f, "2019-01-02"), "<T><Sample>2019-01-02</Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, datetime.date(2019, 1, 2)),
+            "<T><Sample>2019-01-02</Sample></T>",
+        )
+        self.assertEqual(
+            self.to_xml(f, "2019-01-02"), "<T><Sample>2019-01-02</Sample></T>"
+        )
 
 
 class TestDateTimeField(FieldTestMixin, TestCase):
@@ -424,40 +573,87 @@ class TestDateTimeField(FieldTestMixin, TestCase):
 
     def test_value(self):
         f = self.get_field()
-        self.assert_validates(f, datetime.datetime(2019, 1, 2, 12, 30), result=self.mkdt(2019, 1, 2, 12, 30))
-        self.assert_validates(f, "2019-01-02T12:30:00", result=self.mkdt(2019, 1, 2, 12, 30))
-        self.assert_validates(f, datetime.datetime(2019, 1, 2, 12, 30), result=self.mkdt(2019, 1, 2, 12, 30))
-        self.assert_validates(f, "foo", result="foo", errors=[
-            "sample: ISO string too short",
-        ])
-        self.assert_validates(f, [123], result=[123], errors=[
-            "sample: '[123]' is not an instance of str, datetime.date or datetime.datetime",
-        ])
+        self.assert_validates(
+            f,
+            datetime.datetime(2019, 1, 2, 12, 30),
+            result=self.mkdt(2019, 1, 2, 12, 30),
+        )
+        self.assert_validates(
+            f, "2019-01-02T12:30:00", result=self.mkdt(2019, 1, 2, 12, 30)
+        )
+        self.assert_validates(
+            f,
+            datetime.datetime(2019, 1, 2, 12, 30),
+            result=self.mkdt(2019, 1, 2, 12, 30),
+        )
+        self.assert_validates(
+            f,
+            "foo",
+            result="foo",
+            errors=[
+                "sample: ISO string too short",
+            ],
+        )
+        self.assert_validates(
+            f,
+            [123],
+            result=[123],
+            errors=[
+                "sample: '[123]' is not an instance of str, datetime.date or datetime.datetime",
+            ],
+        )
 
     def test_default(self):
         f = self.get_field(default="2019-01-02T12:30:00")
         self.assertEqual(f.clean_value(None), self.mkdt(2019, 1, 2, 12, 30))
-        self.assertEqual(self.to_xml(f, None), "<T><Sample>2019-01-02T12:30:00+01:00</Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, None), "<T><Sample>2019-01-02T12:30:00+01:00</Sample></T>"
+        )
 
     def test_choices(self):
         f = self.get_field(choices=("2019-01-01T12:00:00", "2019-01-02T12:30:00"))
-        self.assert_validates(f, "2019-01-01T12:00:00", result=self.mkdt(2019, 1, 1, 12, 00))
-        self.assert_validates(f, "2019-01-02T12:30:00", result=self.mkdt(2019, 1, 2, 12, 30))
-        self.assert_validates(f, self.mkdt(2019, 1, 2, 12, 15), result=self.mkdt(2019, 1, 2, 12, 15), errors=[
-            "sample: 2019-01-02T12:15:00+01:00 is not a valid choice for this field",
-        ])
-        self.assert_validates(f, None, result=None, errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f, "2019-01-01T12:00:00", result=self.mkdt(2019, 1, 1, 12, 00)
+        )
+        self.assert_validates(
+            f, "2019-01-02T12:30:00", result=self.mkdt(2019, 1, 2, 12, 30)
+        )
+        self.assert_validates(
+            f,
+            self.mkdt(2019, 1, 2, 12, 15),
+            result=self.mkdt(2019, 1, 2, 12, 15),
+            errors=[
+                "sample: 2019-01-02T12:15:00+01:00 is not a valid choice for this field",
+            ],
+        )
+        self.assert_validates(
+            f,
+            None,
+            result=None,
+            errors=[
+                "sample: missing value",
+            ],
+        )
 
     def test_choices_nullable(self):
-        f = self.get_field(choices=("2019-01-01T12:00:00", "2019-01-02T12:30:00"), null=True)
-        self.assert_validates(f, "2019-01-01T12:00:00", result=self.mkdt(2019, 1, 1, 12, 00))
-        self.assert_validates(f, "2019-01-02T12:30:00", result=self.mkdt(2019, 1, 2, 12, 30))
+        f = self.get_field(
+            choices=("2019-01-01T12:00:00", "2019-01-02T12:30:00"), null=True
+        )
+        self.assert_validates(
+            f, "2019-01-01T12:00:00", result=self.mkdt(2019, 1, 1, 12, 00)
+        )
+        self.assert_validates(
+            f, "2019-01-02T12:30:00", result=self.mkdt(2019, 1, 2, 12, 30)
+        )
         self.assert_validates(f, None, result=None)
-        self.assert_validates(f, self.mkdt(2019, 1, 2, 12, 15), result=self.mkdt(2019, 1, 2, 12, 15), errors=[
-            "sample: 2019-01-02T12:15:00+01:00 is not a valid choice for this field",
-        ])
+        self.assert_validates(
+            f,
+            self.mkdt(2019, 1, 2, 12, 15),
+            result=self.mkdt(2019, 1, 2, 12, 15),
+            errors=[
+                "sample: 2019-01-02T12:15:00+01:00 is not a valid choice for this field",
+            ],
+        )
 
     def test_to_python(self):
         f = self.get_field()
@@ -466,14 +662,26 @@ class TestDateTimeField(FieldTestMixin, TestCase):
 
     def test_diff(self):
         f = self.get_field()
-        self.assert_diff_empty(f, self.mkdt(2019, 1, 2, 3, 4, 5), "2019-01-02T03:04:05+01:00")
-        self.assert_field_diff(f, self.mkdt(2019, 1, 2, 3, 4, 5), self.mkdt(2019, 1, 2, 3, 4, 6))
-        self.assert_field_diff(f, self.mkdt(2019, 1, 2, 3, 4, 5), "2019-01-02T03:04:05+02:00")
+        self.assert_diff_empty(
+            f, self.mkdt(2019, 1, 2, 3, 4, 5), "2019-01-02T03:04:05+01:00"
+        )
+        self.assert_field_diff(
+            f, self.mkdt(2019, 1, 2, 3, 4, 5), self.mkdt(2019, 1, 2, 3, 4, 6)
+        )
+        self.assert_field_diff(
+            f, self.mkdt(2019, 1, 2, 3, 4, 5), "2019-01-02T03:04:05+02:00"
+        )
 
     def test_xml(self):
         f = self.get_field(null=True)
-        self.assertEqual(self.to_xml(f, self.mkdt(2019, 1, 2, 12, 30)), "<T><Sample>2019-01-02T12:30:00+01:00</Sample></T>")
-        self.assertEqual(self.to_xml(f, "2019-01-02T12:13:14"), "<T><Sample>2019-01-02T12:13:14+01:00</Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, self.mkdt(2019, 1, 2, 12, 30)),
+            "<T><Sample>2019-01-02T12:30:00+01:00</Sample></T>",
+        )
+        self.assertEqual(
+            self.to_xml(f, "2019-01-02T12:13:14"),
+            "<T><Sample>2019-01-02T12:13:14+01:00</Sample></T>",
+        )
 
 
 class TestProgressivoInvioField(FieldTestMixin, TestCase):
@@ -534,7 +742,10 @@ class TestModelField(FieldTestMixin, TestCase):
     def test_default(self):
         f = self.get_field(default=Sample("test", 7))
         self.assertEqual(f.clean_value(None), Sample("test", 7))
-        self.assertEqual(self.to_xml(f, None), "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, None),
+            "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>",
+        )
 
     def test_to_python(self):
         f = self.get_field()
@@ -543,20 +754,38 @@ class TestModelField(FieldTestMixin, TestCase):
     def test_diff(self):
         f = self.get_field()
         self.assert_diff_empty(f, Sample("test", 7), Sample("test", "7"))
-        self.assert_diff(f, Sample("test", 6), None, [
-            "sample: second is not set",
-        ])
-        self.assert_diff(f, Sample("test", 6), Sample("test", 7), [
-            "sample.value: first: 6, second: 7",
-        ])
-        self.assert_diff(f, Sample("test1", 6), Sample("test2", 7), [
-            "sample.name: first: test1, second: test2",
-            "sample.value: first: 6, second: 7",
-        ])
+        self.assert_diff(
+            f,
+            Sample("test", 6),
+            None,
+            [
+                "sample: second is not set",
+            ],
+        )
+        self.assert_diff(
+            f,
+            Sample("test", 6),
+            Sample("test", 7),
+            [
+                "sample.value: first: 6, second: 7",
+            ],
+        )
+        self.assert_diff(
+            f,
+            Sample("test1", 6),
+            Sample("test2", 7),
+            [
+                "sample.name: first: test1, second: test2",
+                "sample.value: first: 6, second: 7",
+            ],
+        )
 
     def test_xml(self):
         f = self.get_field(null=True)
-        self.assertEqual(self.to_xml(f, Sample("test", 7)), "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, Sample("test", 7)),
+            "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>",
+        )
 
 
 class TestModelListField(FieldTestMixin, TestCase):
@@ -572,9 +801,14 @@ class TestModelListField(FieldTestMixin, TestCase):
 
     def test_value(self):
         f = self.get_field()
-        self.assert_validates(f, [], result=[], errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            [],
+            result=[],
+            errors=[
+                "sample: missing value",
+            ],
+        )
         self.assert_validates(f, [Sample("test", 7)], result=[Sample("test", 7)])
 
         f = self.get_field(null=True)
@@ -583,17 +817,31 @@ class TestModelListField(FieldTestMixin, TestCase):
     def test_min_num(self):
         f = self.get_field(min_num=2)
         self.assertEqual(f.get_construct_default(), [Sample(), Sample()])
-        self.assertEqual(f.clean_value([Sample(), Sample(), Sample()]), [Sample(), Sample()])
+        self.assertEqual(
+            f.clean_value([Sample(), Sample(), Sample()]), [Sample(), Sample()]
+        )
 
-        self.assert_validates(f, [Sample("test", 7)], result=[Sample("test", 7)], errors=[
-            "sample: list must have at least 2 elements, but has only 1",
-        ])
-        self.assert_validates(f, [Sample("test", 6), Sample("test", 7)], result=[Sample("test", 6), Sample("test", 7)])
+        self.assert_validates(
+            f,
+            [Sample("test", 7)],
+            result=[Sample("test", 7)],
+            errors=[
+                "sample: list must have at least 2 elements, but has only 1",
+            ],
+        )
+        self.assert_validates(
+            f,
+            [Sample("test", 6), Sample("test", 7)],
+            result=[Sample("test", 6), Sample("test", 7)],
+        )
 
     def test_default(self):
         f = self.get_field(default=[Sample("test", 7)])
         self.assertEqual(f.clean_value(None), [Sample("test", 7)])
-        self.assertEqual(self.to_xml(f, None), "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, None),
+            "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>",
+        )
 
     def test_to_python(self):
         f = self.get_field()
@@ -604,27 +852,55 @@ class TestModelListField(FieldTestMixin, TestCase):
         self.assert_diff_empty(f, [], None)
         self.assert_diff_empty(f, [Sample("test", 7)], [Sample("test", "7")])
         self.assert_diff_empty(f, [Sample("test", 6)], [Sample("test", 6), None])
-        self.assert_diff(f, [Sample("test", 6)], None, [
-            "sample: second is not set",
-        ])
-        self.assert_diff(f, [Sample("test", 6)], [], [
-            "sample: second is not set",
-        ])
-        self.assert_diff(f, [Sample("test", 6)], [Sample("test", 7)], [
-            "sample.0.value: first: 6, second: 7",
-        ])
-        self.assert_diff(f, [Sample("test", 6)], [Sample("test", 6), Sample("test", 7)], [
-            "sample: second has 1 extra element",
-        ])
-        self.assert_diff(f, [Sample("test", 6)], [Sample("test", 5), Sample("test", 7)], [
-            "sample.0.value: first: 6, second: 5",
-            "sample: second has 1 extra element",
-        ])
+        self.assert_diff(
+            f,
+            [Sample("test", 6)],
+            None,
+            [
+                "sample: second is not set",
+            ],
+        )
+        self.assert_diff(
+            f,
+            [Sample("test", 6)],
+            [],
+            [
+                "sample: second is not set",
+            ],
+        )
+        self.assert_diff(
+            f,
+            [Sample("test", 6)],
+            [Sample("test", 7)],
+            [
+                "sample.0.value: first: 6, second: 7",
+            ],
+        )
+        self.assert_diff(
+            f,
+            [Sample("test", 6)],
+            [Sample("test", 6), Sample("test", 7)],
+            [
+                "sample: second has 1 extra element",
+            ],
+        )
+        self.assert_diff(
+            f,
+            [Sample("test", 6)],
+            [Sample("test", 5), Sample("test", 7)],
+            [
+                "sample.0.value: first: 6, second: 5",
+                "sample: second has 1 extra element",
+            ],
+        )
 
     def test_xml(self):
         f = self.get_field(null=True)
         self.assertIsNone(self.to_xml(f, []))
-        self.assertEqual(self.to_xml(f, [Sample("test", 7)]), "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, [Sample("test", 7)]),
+            "<T><Sample><Name>test</Name><Value>7</Value></Sample></T>",
+        )
 
 
 class TestListField(FieldTestMixin, TestCase):
@@ -640,9 +916,14 @@ class TestListField(FieldTestMixin, TestCase):
 
     def test_value(self):
         f = self.get_field()
-        self.assert_validates(f, [], result=[], errors=[
-            "sample: missing value",
-        ])
+        self.assert_validates(
+            f,
+            [],
+            result=[],
+            errors=[
+                "sample: missing value",
+            ],
+        )
         self.assert_validates(f, ["test1", "test2"], result=["test1", "test2"])
 
         f = self.get_field(null=True)
@@ -653,40 +934,67 @@ class TestListField(FieldTestMixin, TestCase):
         self.assertEqual(f.get_construct_default(), [None, None])
         self.assertEqual(f.clean_value([None, None, None]), [None, None])
 
-        self.assert_validates(f, ["test1"], result=["test1"], errors=[
-            "sample: list must have at least 2 elements, but has only 1",
-        ])
+        self.assert_validates(
+            f,
+            ["test1"],
+            result=["test1"],
+            errors=[
+                "sample: list must have at least 2 elements, but has only 1",
+            ],
+        )
         self.assert_validates(f, ["test1", "test2"], result=["test1", "test2"])
 
     def test_default(self):
         f = self.get_field(default=["test1", "test2"])
         self.assertEqual(f.clean_value(None), ["test1", "test2"])
-        self.assertEqual(self.to_xml(f, None), "<T><Sample>test1</Sample><Sample>test2</Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, None), "<T><Sample>test1</Sample><Sample>test2</Sample></T>"
+        )
 
     def test_to_python(self):
         f = self.get_field()
         self.assert_to_python_works(f, ["test1", "foo"])
 
         f = super().get_field(fields.DateTimeField())
-        self.assert_to_python_works(f, [self.mkdt(2019, 1, 2, 3, 4), self.mkdt(2019, 2, 3, 4, 5)])
+        self.assert_to_python_works(
+            f, [self.mkdt(2019, 1, 2, 3, 4), self.mkdt(2019, 2, 3, 4, 5)]
+        )
 
     def test_diff(self):
         f = self.get_field()
         self.assert_diff_empty(f, [], None)
         self.assert_diff_empty(f, ["test"], ["test"])
         self.assert_diff_empty(f, ["test"], ["test", None])
-        self.assert_diff(f, ["test"], ["test1"], [
-            "sample.0: first: test, second: test1",
-        ])
-        self.assert_diff(f, ["test"], ["test", "test"], [
-            "sample: second has 1 extra element",
-        ])
-        self.assert_diff(f, ["test"], ["test1", "test2"], [
-            "sample.0: first: test, second: test1",
-            "sample: second has 1 extra element",
-        ])
+        self.assert_diff(
+            f,
+            ["test"],
+            ["test1"],
+            [
+                "sample.0: first: test, second: test1",
+            ],
+        )
+        self.assert_diff(
+            f,
+            ["test"],
+            ["test", "test"],
+            [
+                "sample: second has 1 extra element",
+            ],
+        )
+        self.assert_diff(
+            f,
+            ["test"],
+            ["test1", "test2"],
+            [
+                "sample.0: first: test, second: test1",
+                "sample: second has 1 extra element",
+            ],
+        )
 
     def test_xml(self):
         f = self.get_field(null=True)
         self.assertIsNone(self.to_xml(f, []))
-        self.assertEqual(self.to_xml(f, ["test", "foo"]), "<T><Sample>test</Sample><Sample>foo</Sample></T>")
+        self.assertEqual(
+            self.to_xml(f, ["test", "foo"]),
+            "<T><Sample>test</Sample><Sample>foo</Sample></T>",
+        )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,12 +1,11 @@
-from unittest import TestCase
-from a38 import fields
-from a38 import models
-from a38 import validation
-from a38.builder import Builder
-from a38.diff import Diff
-from decimal import Decimal
 import datetime
 import io
+from decimal import Decimal
+from unittest import TestCase
+
+from a38 import fields, models, validation
+from a38.builder import Builder
+from a38.diff import Diff
 
 NS = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
-from a38 import fields
-from a38 import models
+
+from a38 import fields, models
 
 
 class Sample(models.Model):

--- a/tests/test_p7m.py
+++ b/tests/test_p7m.py
@@ -72,10 +72,11 @@ class TestSignature(TestCase):
         p7m = P7M("tests/data/test.txt.p7m")
         data = p7m.get_payload()
         self.assertEqual(
-                data,
-                "This is only a test payload.\n"
-                "\n"
-                "Questo è solo un payload di test.\n".encode("utf8"))
+            data,
+            "This is only a test payload.\n"
+            "\n"
+            "Questo è solo un payload di test.\n".encode("utf8"),
+        )
 
     def test_verify(self):
         p7m = P7M("tests/data/test.txt.p7m")
@@ -89,7 +90,11 @@ class TestSignature(TestCase):
         if p7m.is_expired():
             self.skipTest("test signature has expired and needs to be regenerated")
         data_mid = len(p7m.data) // 2
-        p7m.data = p7m.data[:data_mid] + bytes([p7m.data[data_mid] + 1]) + p7m.data[data_mid + 1:]
+        p7m.data = (
+            p7m.data[:data_mid]
+            + bytes([p7m.data[data_mid] + 1])
+            + p7m.data[data_mid + 1 :]
+        )
         with self.capath() as capath:
             with self.assertRaises(InvalidSignatureError):
                 p7m.verify_signature(capath)
@@ -103,7 +108,9 @@ class TestSignature(TestCase):
         encap_content_info["content"] = b"All your base are belong to us"
         p7m.data = p7m.content_info.dump()
         with self.capath() as capath:
-            with self.assertRaisesRegexp(InvalidSignatureError, r"routines:CMS_verify:content verify error"):
+            with self.assertRaisesRegexp(
+                InvalidSignatureError, r"routines:CMS_verify:content verify error"
+            ):
                 p7m.verify_signature(capath)
 
     def test_verify_noca(self):
@@ -111,5 +118,8 @@ class TestSignature(TestCase):
         if p7m.is_expired():
             self.skipTest("test signature has expired and needs to be regenerated")
         with tempfile.TemporaryDirectory() as capath:
-            with self.assertRaisesRegexp(InvalidSignatureError, r"Verify error:unable to get local issuer certificate"):
+            with self.assertRaisesRegexp(
+                InvalidSignatureError,
+                r"Verify error:unable to get local issuer certificate",
+            ):
                 p7m.verify_signature(capath)

--- a/tests/test_p7m.py
+++ b/tests/test_p7m.py
@@ -1,7 +1,8 @@
-from unittest import TestCase
+import os
 import tempfile
 from contextlib import contextmanager
-import os
+from unittest import TestCase
+
 from a38.crypto import P7M, InvalidSignatureError
 
 # This is the CA certificate used to validate tests/data/test.txt.p7m


### PR DESCRIPTION
This is the PR related to issue https://github.com/Truelite/python-a38/issues/16

I applied where easy `isort`, `black`, `flake8` and `bandit`. 
I left out from `flake8` the cyclomatic complexity as some parts of the code reach level 15. I usually set this cyclomatic complexity to 4.

However, `pylint` and `pytype` prove to be quite deep and aggressive. 
There are some decisions to take in there, so I left them commented out with some TODOs that could provide some context.

It seems the project is setup to use `mypy` - I found `pytype` being more effective when checking types. Also: `pytype` usually works out of the box without providing extra configuration to the command when invoking it.

The command `bandit` could be made more strict to increase the level of vulnerability checks.

Once all the tools are sorted out it would be very useful to add a linting stage to the CI job.

I hope this is useful and makes sense - thanks again for this great project you released :pray: 