### PR TITLE
Feature/lint poc

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -13,6 +13,8 @@ jobs:
         run: make install-os
       - name: Install Pip packages
         run: make install-py
+      - name: Lint
+        run: make lint
       - name: Run the tests
         run: make test
       - name: Install the package

--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Work around Apt caching issues
+        run: make ci-workaround
       - name: Install OS packages
         run: make install-os
       - name: Install Pip packages

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,19 @@ install-os:
 
 install-py:
 	pip install -r requirements-lib.txt
+	pip install -r requirements-devops.txt
 
 test:
 	sh test-coverage
 
 install-package:
 	pip install .
+
+clean:
+	rm --recursive --force \
+		$(PWD)/build \
+		$(PWD)/dist \
+		$(PWD)/htmlcov \
+		$(PWD)/a38.egg-info \
+		$(PWD)/.coverage
+

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ lint:
 		$(PWD)/a38 \
 		$(PWD)/tests
 	flake8 \
-		--ignore=E203,E501,W503 \
+		--ignore=E126,E203,E501,W503 \
+		--max-line-length 120 \
+		--indent-size 4 \
 		--jobs=8 \
 		$(PWD)/a38 \
 		$(PWD)/tests

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,14 @@ lint-dev:
 		--atomic \
 		$(PWD)/a38 \
 		$(PWD)/tests
+	$(eval PIP_DEPS=$(shell awk '{printf("%s,",$$1)}' requirements-lib.txt | sed '$$s/,$$//'))
+	autoflake \
+		--imports=$(PIP_DEPS) \
+		--recursive \
+		--in-place \
+		--remove-unused-variables \
+		$(PWD)/a38 \
+		$(PWD)/tests
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,20 @@ clean:
 		$(PWD)/a38.egg-info \
 		$(PWD)/.coverage
 
+lint:
+	isort \
+		--check \
+		$(PWD)/a38 \
+		$(PWD)/tests
+	flake8 \
+		--ignore=E203,E501,W503 \
+		--jobs=8 \
+		$(PWD)/a38 \
+		$(PWD)/tests
+	bandit \
+		--recursive \
+		--number=3 \
+		-lll \
+		-iii \
+		$(PWD)/a38 \
+		$(PWD)/tests

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,9 @@ lint:
 		-iii \
 		$(PWD)/a38 \
 		$(PWD)/tests
+
+lint-dev:
+	isort \
+		--atomic \
+		$(PWD)/a38 \
+		$(PWD)/tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install-os:
-	sudo apt-get install \
+	sudo apt-get -o Acquire::Retries=5 install \
 		openssl \
 		wkhtmltopdf \
 		eatmydata \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ci-workaround:
+	sudo sed -i 's/azure\.//' /etc/apt/sources.list
+	sudo apt-get -o Acquire::Retries=5 update
+
 install-os:
 	sudo apt-get -o Acquire::Retries=5 install \
 		openssl \

--- a/Makefile
+++ b/Makefile
@@ -27,27 +27,31 @@ lint:
 	isort \
 		--check \
 		$(PWD)/a38 \
-		$(PWD)/tests
+		$(PWD)/tests \
+		setup.py
 	flake8 \
 		--ignore=E126,E203,E501,W503 \
 		--max-line-length 120 \
 		--indent-size 4 \
 		--jobs=8 \
 		$(PWD)/a38 \
-		$(PWD)/tests
+		$(PWD)/tests \
+		setup.py
 	bandit \
 		--recursive \
 		--number=3 \
 		-lll \
 		-iii \
 		$(PWD)/a38 \
-		$(PWD)/tests
+		$(PWD)/tests \
+		setup.py
 
 lint-dev:
 	isort \
 		--atomic \
 		$(PWD)/a38 \
-		$(PWD)/tests
+		$(PWD)/tests \
+		setup.py
 	$(eval PIP_DEPS=$(shell awk '{printf("%s,",$$1)}' requirements-lib.txt | sed '$$s/,$$//'))
 	autoflake \
 		--imports=$(PIP_DEPS) \
@@ -55,7 +59,5 @@ lint-dev:
 		--in-place \
 		--remove-unused-variables \
 		$(PWD)/a38 \
-		$(PWD)/tests
-
-
-
+		$(PWD)/tests \
+		setup.py

--- a/a38/builder.py
+++ b/a38/builder.py
@@ -1,5 +1,6 @@
-from contextlib import contextmanager
 import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+
 try:
     import lxml.etree
     HAVE_LXML = True

--- a/a38/crypto.py
+++ b/a38/crypto.py
@@ -1,11 +1,13 @@
-from typing import Union, BinaryIO
-from asn1crypto.cms import ContentInfo
-import io
 import base64
 import binascii
-import subprocess
 import datetime
+import io
+import subprocess
 import xml.etree.ElementTree as ET
+from typing import BinaryIO, Union
+
+from asn1crypto.cms import ContentInfo
+
 from . import fattura as a38
 
 

--- a/a38/diff.py
+++ b/a38/diff.py
@@ -1,6 +1,7 @@
-from typing import Optional, Any, List
-from .traversal import Annotation, Traversal
+from typing import Any, List, Optional
+
 from . import fields
+from .traversal import Annotation, Traversal
 
 
 class Difference(Annotation):

--- a/a38/fattura.py
+++ b/a38/fattura.py
@@ -443,7 +443,7 @@ class DatiBeniServizi(models.Model):
 
         self.dati_riepilogo = []
         for aliquota, linee in sorted(by_aliquota.items()):
-            imponibile = sum(l.prezzo_totale for l in linee)
+            imponibile = sum(linea.prezzo_totale for linea in linee)
             imposta = imponibile * aliquota / 100
             self.dati_riepilogo.append(
                     DatiRiepilogo(

--- a/a38/fattura.py
+++ b/a38/fattura.py
@@ -1,6 +1,6 @@
-from . import models
-from . import fields
 import re
+
+from . import fields, models
 
 #
 # This file describes the data model of the Italian Fattura Elettronica.

--- a/a38/fattura_semplificata.py
+++ b/a38/fattura_semplificata.py
@@ -1,9 +1,6 @@
-from .fattura import (
-    IdTrasmittente, IdFiscaleIVA, Sede, StabileOrganizzazione, IscrizioneREA,
-    FullNameMixin, Allegati
-)
-from . import models
-from . import fields
+from . import fields, models
+from .fattura import (Allegati, FullNameMixin, IdFiscaleIVA, IdTrasmittente,
+                      IscrizioneREA, Sede, StabileOrganizzazione)
 
 NS10 = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0"
 

--- a/a38/fields.py
+++ b/a38/fields.py
@@ -1,16 +1,17 @@
-from typing import Optional, Any, TypeVar, Generic, Sequence, List
-from dateutil.parser import isoparse
+import base64
 import datetime
 import decimal
-import re
-from . import validation
-from . import builder
-from .diff import Diff
-from decimal import Decimal
-import base64
-import time
-import pytz
 import logging
+import re
+import time
+from decimal import Decimal
+from typing import Any, Generic, List, Optional, Sequence, TypeVar
+
+import pytz
+from dateutil.parser import isoparse
+
+from . import builder, validation
+from .diff import Diff
 
 log = logging.getLogger("a38.fields")
 

--- a/a38/models.py
+++ b/a38/models.py
@@ -1,7 +1,8 @@
-from typing import Dict, Any, Optional, Tuple
+from collections import OrderedDict, defaultdict
+from typing import Any, Dict, Optional, Tuple
+
 from .fields import Field, ModelField
 from .validation import Validation
-from collections import OrderedDict, defaultdict
 
 
 class ModelBase:

--- a/a38/render.py
+++ b/a38/render.py
@@ -1,7 +1,8 @@
-from typing import Optional
-import tempfile
-import subprocess
 import os
+import subprocess
+import tempfile
+from typing import Optional
+
 try:
     import lxml.etree
     HAVE_LXML = True

--- a/a38/traversal.py
+++ b/a38/traversal.py
@@ -1,5 +1,6 @@
-from typing import Optional
 from contextlib import contextmanager
+from typing import Optional
+
 from . import fields
 
 

--- a/a38/trustedlist.py
+++ b/a38/trustedlist.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict
 
+from cryptography import x509
+
 from . import fields, models
 
 log = logging.getLogger("__name__")
@@ -154,7 +156,7 @@ def load_url(url: str):
     return auto_from_etree(root)
 
 
-def load_certs() -> Dict[str, "cryptography.x509.Certificate"]:
+def load_certs() -> Dict[str, x509.Certificate]:
     """
     Download trusted list certificates for Italy, parse them and return a dict
     mapping certificate names good for use as file names to cryptography.x509

--- a/a38/trustedlist.py
+++ b/a38/trustedlist.py
@@ -1,13 +1,13 @@
-from typing import Dict
-import re
-from collections import defaultdict
-import xml.etree.ElementTree as ET
-import logging
 import base64
+import logging
+import re
 import subprocess
+import xml.etree.ElementTree as ET
+from collections import defaultdict
 from pathlib import Path
-from . import models
-from . import fields
+from typing import Dict
+
+from . import fields, models
 
 log = logging.getLogger("__name__")
 

--- a/a38/validation.py
+++ b/a38/validation.py
@@ -1,6 +1,7 @@
-from typing import Optional, List, Sequence, Union
-from .traversal import Annotation, Traversal
+from typing import List, Optional, Sequence, Union
+
 from . import fields
+from .traversal import Annotation, Traversal
 
 
 class ValidationError(Annotation):

--- a/requirements-devops.txt
+++ b/requirements-devops.txt
@@ -1,0 +1,4 @@
+isort
+autoflake
+flake8
+bandit

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@ from setuptools import setup
 with open("README.md", "r") as fp:
     long_description = fp.read()
 
+
 def parse_requirements(filename):
-    lineiter = (line.strip() for line in open(filename))
-    return [line for line in lineiter if line and not line.startswith("#")]
+    line_iter = (line.strip() for line in open(filename))
+    return [line for line in line_iter if line and not line.startswith("#")]
+
 
 setup(
     name="a38",

--- a/tests/test_fattura.py
+++ b/tests/test_fattura.py
@@ -117,7 +117,7 @@ class TestDatiBeniServizi(TestFatturaMixin, TestCase):
         o.build_dati_riepilogo()
 
         self.assertEqual(len(o.dati_riepilogo), 2)
-        self.assertEqual(o.dati_riepilogo[0], a38.DatiRiepilogo(aliquota_iva="10", imponibile_importo="1.75",  imposta="0.175", esigibilita_iva="I"))
+        self.assertEqual(o.dati_riepilogo[0], a38.DatiRiepilogo(aliquota_iva="10", imponibile_importo="1.75", imposta="0.175", esigibilita_iva="I"))
         self.assertEqual(o.dati_riepilogo[1], a38.DatiRiepilogo(aliquota_iva="22", imponibile_importo="14.40", imposta="3.168", esigibilita_iva="I"))
 
 

--- a/tests/test_fattura.py
+++ b/tests/test_fattura.py
@@ -1,9 +1,10 @@
-from unittest import TestCase, SkipTest
-import a38.fattura as a38
-from a38 import validation
-from decimal import Decimal
 import datetime
 import io
+from decimal import Decimal
+from unittest import SkipTest, TestCase
+
+import a38.fattura as a38
+from a38 import validation
 
 
 class TestFatturaMixin:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,12 +1,11 @@
-from unittest import TestCase
-from a38 import fields
-from a38 import models
-from a38 import validation
-from a38.builder import Builder
-from a38.diff import Diff
-from decimal import Decimal
 import datetime
 import io
+from decimal import Decimal
+from unittest import TestCase
+
+from a38 import fields, models, validation
+from a38.builder import Builder
+from a38.diff import Diff
 
 NS = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
-from a38 import fields
-from a38 import models
+
+from a38 import fields, models
 
 
 class Sample(models.Model):

--- a/tests/test_p7m.py
+++ b/tests/test_p7m.py
@@ -1,7 +1,8 @@
-from unittest import TestCase
+import os
 import tempfile
 from contextlib import contextmanager
-import os
+from unittest import TestCase
+
 from a38.crypto import P7M, InvalidSignatureError
 
 # This is the CA certificate used to validate tests/data/test.txt.p7m


### PR DESCRIPTION
This is the PR as an iteration over the original PR https://github.com/Truelite/python-a38/pull/17 (see also issue https://github.com/Truelite/python-a38/issues/16).

I had to take some decisions because `flake8` was complaining about things that are automatically fixed by `black`. This is due to potentially non-commutative rules applied to the code base where the order matters.

I fixed some things and left out (ignored) other things e.g. `E126 continuation line over-indented for hanging indent`.

Also I left out other undetected things that you may want to look into - stuff as or similar to:

```
from . import fields, models
...
from .traversal import Annotation, Traversal
```

Usually you may want to be as explicit as possible by replacing `.` with the library root package `a38`. However, I understand this is a matter of personal preference.

I hope this makes sense :pray: 
