### PR TITLE
Update Natura IVA and Tipo Documento

### DIFF
--- a/a38/consts.py
+++ b/a38/consts.py
@@ -1,0 +1,62 @@
+# see table at page 26 for the PDF document
+# GUIDA ALLA COMPILAZIONE DELLE FATTURE ELETTRONICHE E DELL’ESTEROMETRO
+# from AdE (Agenzia Delle Entrate), version 1.6 - 2022/02/04
+# https://www.agenziaentrate.gov.it/portale/documents/20143/451259/Guida_compilazione-FE_2021_07_07.pdf/e6fcdd04-a7bd-e6f2-ced4-cac04403a768
+# see also:
+# - https://agenziaentrate.gov.it/portale/documents/20143/296703/Variazioni+alle+specifiche+tecniche+fatture+elettroniche2021-07-02.pdf
+# - https://www.agenziaentrate.gov.it/portale/web/guest/schede/comunicazioni/fatture-e-corrispettivi/faq-fe/risposte-alle-domande-piu-frequenti-categoria/compilazione-della-fattura-elettronica
+NATURA_IVA = (
+    "N1",
+    "N2",
+    "N2.1",  # non soggette ad IVA ai sensi degli artt. da 7 a 7-septies del D.P.R. n. 633/72
+    "N2.2",  # non soggette - altri casi
+    "N3",
+    "N3.1",  # non imponibili - esportazioni
+    "N3.2",  # non imponibili - cessioni intracomunitarie
+    "N3.3",  # non imponibili - cessioni verso San Marino
+    "N3.4",  # non imponibili - operazioni assimilate alle cessioni all'esportazione
+    "N3.5",  # non imponibili - a seguito di dichiarazioni d'intento
+    "N3.6",  # non imponibili - altre operazioni
+    "N4",
+    "N5",
+    "N6",
+    "N6.1",  # inversione contabile - cessione di rottami e altri materiali di recupero
+    "N6.2",  # inversione contabile – cessione di oro e argento ai sensi della legge 7/2000 nonché di oreficeria usata ad OPO
+    "N6.3",  # inversione contabile - subappalto nel settore edile
+    "N6.4",  # inversione contabile - cessione di fabbricati
+    "N6.5",  # inversione contabile - cessione di telefoni cellulari
+    "N6.6",  # inversione contabile - cessione di prodotti elettronici
+    "N6.7",  # inversione contabile - prestazioni comparto edile e settori connessi
+    "N6.8",  # inversione contabile - operazioni settore energetico
+    "N6.9",  # inversione contabile - altri casi
+    "N7",
+)
+
+# see pages 1 to 25 for the PDF document
+# GUIDA ALLA COMPILAZIONE DELLE FATTURE ELETTRONICHE E DELL’ESTEROMETRO
+# from AdE (Agenzia Delle Entrate), version 1.6 - 2022/02/04
+# https://www.agenziaentrate.gov.it/portale/documents/20143/451259/Guida_compilazione-FE_2021_07_07.pdf/e6fcdd04-a7bd-e6f2-ced4-cac04403a768
+TIPO_DOCUMENTO = (
+    "TD01",  # FATTURA
+    "TD02",  # ACCONTO/ANTICIPO SU FATTURA
+    "TD03",  # ACCONTO/ANTICIPO SU PARCELLA
+    "TD04",  # NOTA DI CREDITO
+    "TD05",  # NOTA DI DEBITO
+    "TD06",  # PARCELLA
+    "TD07",  # FATTURA SEMPLIFICATA
+    "TD08",  # NOTA DI CREDITO SEMPLIFICATA
+    "TD09",  # NOTA DI DEBITO SEMPLIFICATA
+    "TD16",  # INTEGRAZIONE FATTURA DA REVERSE CHARGE INTERNO
+    "TD17",  # INTEGRAZIONE/AUTOFATTURA PER ACQUISTO SERVIZI DALL'ESTERO
+    "TD18",  # INTEGRAZIONE PER ACQUISTO DI BENI INTRACOMUNITARI
+    "TD19",  # INTEGRAZIONE/AUTOFATTURA PER ACQUISTO DI BENI EX ART. 17 C.2 D.P.R. 633/72
+    "TD20",  # AUTOFATTURA PER REGOLARIZZAZIONE E INTEGRAZIONE DELLE FATTURE
+             # (EX ART. 6 COMMI 8 E 9-BIS D. LGS. 471/97 O ART. 46 C.5 D.L. 331/93)
+    "TD21",  # AUTOFATTURA PER SPLAFONAMENTO
+    "TD22",  # ESTRAZIONE BENI DA DEPOSITO IVA
+    "TD23",  # ESTRAZIONE BENI DA DEPOSITO IVA CON VERSAMENTO DELL'IVA
+    "TD24",  # FATTURA DIFFERITA DI CUI ALL'ART. 21, COMMA 4, TERZO PERIODO, LETT. A), DEL D.P.R. N. 633/72
+    "TD25",  # FATTURA DIFFERITA DI CUI ALL'ART. 21, COMMA 4, TERZO PERIODO LETT. B), DEL D.P.R. N. 633/72
+    "TD26",  # CESSIONE DI BENI AMMORTIZZABILI E PER PASSAGGI INTERNI (EX ART. 36 D.P.R. 633/72)
+    "TD27",  # FATTURA PER AUTOCONSUMO O PER CESSIONI GRATUITE SENZA RIVALSA
+)

--- a/a38/fattura.py
+++ b/a38/fattura.py
@@ -1,6 +1,6 @@
-from . import models
-from . import fields
 import re
+
+from . import consts, fields, models
 
 #
 # This file describes the data model of the Italian Fattura Elettronica.
@@ -277,7 +277,7 @@ class DatiCassaPrevidenziale(models.Model):
     imponibile_cassa = fields.DecimalField(max_length=15)
     aliquota_iva = fields.DecimalField(max_length=6, xmltag="AliquotaIVA")
     ritenuta = fields.StringField(length=2, choices=("SI",), null=True)
-    natura = fields.StringField(length=2, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"), null=True)
+    natura = fields.StringField(length=2, choices=consts.NATURA_IVA, null=True)
     riferimento_amministrazione = fields.StringField(max_length=20, null=True)
 
     def validate_model(self, validation):
@@ -297,7 +297,7 @@ class ScontoMaggiorazione(models.Model):
 
 
 class DatiGeneraliDocumento(models.Model):
-    tipo_documento = fields.StringField(length=4, choices=("TD01", "TD02", "TD03", "TD04", "TD05", "TD06"))
+    tipo_documento = fields.StringField(length=4, choices=consts.TIPO_DOCUMENTO)
     divisa = fields.StringField()
     data = fields.DateField()
     numero = fields.StringField(max_length=20)
@@ -354,7 +354,7 @@ class DettaglioLinee(models.Model):
     prezzo_totale = fields.DecimalField(max_length=21)
     aliquota_iva = fields.DecimalField(xmltag="AliquotaIVA", max_length=6)
     ritenuta = fields.StringField(length=2, choices=("SI",), null=True)
-    natura = fields.StringField(length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"))
+    natura = fields.StringField(length=2, null=True, choices=consts.NATURA_IVA)
     riferimento_amministrazione = fields.StringField(max_length=20, null=True)
     altri_dati_gestionali = fields.ModelListField(AltriDatiGestionali, null=True)
 
@@ -374,7 +374,7 @@ class DettaglioLinee(models.Model):
 
 class DatiRiepilogo(models.Model):
     aliquota_iva = fields.DecimalField(xmltag="AliquotaIVA", max_length=6)
-    natura = fields.StringField(length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"))
+    natura = fields.StringField(length=2, null=True, choices=consts.NATURA_IVA)
     spese_accessorie = fields.DecimalField(max_length=15, null=True)
     arrotondamento = fields.DecimalField(max_length=21, null=True)
     # FIXME: Su questo valore il sistema effettua un controllo per verificare

--- a/a38/fattura_semplificata.py
+++ b/a38/fattura_semplificata.py
@@ -1,9 +1,6 @@
-from .fattura import (
-    IdTrasmittente, IdFiscaleIVA, Sede, StabileOrganizzazione, IscrizioneREA,
-    FullNameMixin, Allegati
-)
-from . import models
-from . import fields
+from . import consts, fields, models
+from .fattura import (Allegati, FullNameMixin, IdFiscaleIVA, IdTrasmittente,
+                      IscrizioneREA, Sede, StabileOrganizzazione)
 
 NS10 = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0"
 
@@ -92,7 +89,7 @@ class DatiBeniServizi(models.Model):
     descrizione = fields.StringField(max_length=1000)
     importo = fields.DecimalField(max_length=15)
     dati_iva = DatiIVA
-    natura = fields.StringField(length=2, null=True, choices=("N1", "N2", "N3", "N4", "N5", "N6", "N7"))
+    natura = fields.StringField(length=2, null=True, choices=consts.NATURA_IVA)
     riferimento_normativo = fields.StringField(max_length=100, null=True)
 
 


### PR DESCRIPTION
I factored out "Natura IVA" and "Tipo Documento" to the file `consts.py`. 
I also applied `isort` and `flake8` to the impacted source code forseeing potential related to PR https://github.com/Truelite/python-a38/pull/20 it probably makes sense waiting for that PR to be merged before revisiting this one and solve merging conflicts that could arise.

Related issue: https://github.com/Truelite/python-a38/issues/18