### PR TITLE
Trigger Github action on push to master, pull request and manual

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -1,8 +1,15 @@
 ---
 name: Python A38
 
-# only manual and pull requests
-on: [workflow_dispatch, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  # invoke the pipeline manually
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This PR aims at keeping the `HEAD` commit in the `master` branch always covered with a pipeline execution.

This change should allow to run the pipeline:

- when there's a push to `master`
- when a pull request is merged to `master` (for some reason it seems both scenarios are needed)
- when someone manually triggers it

Reference docs:

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
